### PR TITLE
Fixed #12: Select Fields/Pickers Autoclose IE

### DIFF
--- a/src/js/Menus/Menu.js
+++ b/src/js/Menus/Menu.js
@@ -44,12 +44,11 @@ export default class Menu extends Component {
 
   componentDidUpdate(prevProps) {
     const { isOpen, autoclose, close } = this.props;
-    if(close && autoclose && isOpen && !prevProps.isOpen) {
+    if(!close || !autoclose || isOpen === prevProps.isOpen) { return; }
+    if(isOpen) {
       window.addEventListener('click', this.closeOnOutsideClick);
-    } else if(!isOpen && prevProps.isOpen) {
-      if(close && autoclose) {
-        window.removeEventListener('click', this.closeOnOutsideClick);
-      }
+    } else {
+      window.removeEventListener('click', this.closeOnOutsideClick);
     }
   }
 

--- a/src/js/SelectFields/SelectField.js
+++ b/src/js/SelectFields/SelectField.js
@@ -202,6 +202,8 @@ export default class SelectField extends Component {
   };
 
   handleClick = (e) => {
+    // Prevents IE for toggling twice for some reason.
+    e.preventDefault();
     this.props.onClick && this.props.onClick(e);
     this.toggle();
   };


### PR DESCRIPTION
IE Triggered the toggle function twice for the select field. The fix was to preventDefault on the click event.

Clean up the Menu update for adding the window listener.