### PR TITLE
Improve TextField props

### DIFF
--- a/lib/TextFields/TextField.js
+++ b/lib/TextFields/TextField.js
@@ -127,30 +127,64 @@ var TextField = function (_Component) {
   _createClass(TextField, [{
     key: 'render',
     value: function render() {
+      var _props = this.props;
       var _state = this.state;
       var active = _state.active;
-      var currentRows = _state.currentRows;
       var areaHeight = _state.areaHeight;
-      var _props = this.props;
       var className = _props.className;
-      var containerClassName = _props.containerClassName;
-      var label = _props.label;
-      var placeholder = _props.placeholder;
-      var maxLength = _props.maxLength;
-      var helpText = _props.helpText;
+      var currentRows = _state.currentRows;
       var errorText = _props.errorText;
       var floatingLabel = _props.floatingLabel;
-      var icon = _props.icon;
-      var rightIcon = _props.rightIcon;
-      var lineDirection = _props.lineDirection;
-      var rows = _props.rows;
-      var maxRows = _props.maxRows;
-      var style = _props.style;
-      var required = _props.required;
-      var helpOnFocus = _props.helpOnFocus;
       var fullWidth = _props.fullWidth;
+      var helpOnFocus = _props.helpOnFocus;
+      var helpText = _props.helpText;
+      var icon = _props.icon;
+      var inputClassName = _props.inputClassName;
+      var inputStyle = _props.inputStyle;
+      var label = _props.label;
+      var lineDirection = _props.lineDirection;
+      var maxLength = _props.maxLength;
+      var maxRows = _props.maxRows;
+      var onInput = _props.onInput;
+      var onInvalid = _props.onInvalid;
+      var onKeyDown = _props.onKeyDown;
+      var onKeyPress = _props.onKeyPress;
+      var onKeyUp = _props.onKeyUp;
+      var onSelect = _props.onSelect;
+      var placeholder = _props.placeholder;
+      var required = _props.required;
+      var rightIcon = _props.rightIcon;
+      var rows = _props.rows;
+      var type = _props.type;
 
-      var props = _objectWithoutProperties(_props, ['className', 'containerClassName', 'label', 'placeholder', 'maxLength', 'helpText', 'errorText', 'floatingLabel', 'icon', 'rightIcon', 'lineDirection', 'rows', 'maxRows', 'style', 'required', 'helpOnFocus', 'fullWidth']);
+      var remainingProps = _objectWithoutProperties(_props, [
+        'className',
+        'errorText',
+        'floatingLabel',
+        'fullWidth',
+        'helpOnFocus',
+        'helpText',
+        'icon',
+        'inputClassName',
+        'inputStyle',
+        'label',
+        'lineDirection',
+        'maxLength',
+        'maxRows',
+        'onBlur',
+        'onChange',
+        'onFocus',
+        'onInput',
+        'onInvalid',
+        'onKeyDown',
+        'onKeyPress',
+        'onKeyUp',
+        'onSelect',
+        'placeholder',
+        'required',
+        'rightIcon',
+        'rows',
+        'type']);
 
       var value = this.getValue();
       var error = !!errorText || !!maxLength && value.length > maxLength;
@@ -191,19 +225,27 @@ var TextField = function (_Component) {
         });
       }
 
-      var textFieldProps = _extends({}, props, {
+      var textFieldProps = {
         value: value,
-        className: (0, _classnames2.default)('md-text-field', className, {
+        className: (0, _classnames2.default)('md-text-field', inputClassName, {
           active: active,
           'floating-label': useFloatingLabel,
           'single-line': !useFloatingLabel && !multiline,
           'multi-line': multiline,
           'full-width': fullWidth
         }),
-        onFocus: this.handleFocus,
+        inputStyle: inputStyle,
         onBlur: this.handleBlur,
-        onChange: this.handleChange
-      });
+        onChange: this.handleChange,
+        onFocus: this.handleFocus,
+        onInput: onInput,
+        onIvalid: onInvalid,
+        onKeyDown: onKeyDown,
+        onKeyPress: onKeyPress,
+        onKeyUp: onKeyUp,
+        onSelect: onSelect,
+        type: type
+      };
 
       var textField = void 0;
       if (multiline) {
@@ -226,20 +268,19 @@ var TextField = function (_Component) {
         }));
       } else {
         textField = _react2.default.createElement('input', _extends({}, textFieldProps, {
-          style: style,
+          style: inputStyle,
           placeholder: !useFloatingLabel ? placeholder || label : placeholder
         }));
       }
 
-      return _react2.default.createElement(
-        'div',
-        {
-          className: (0, _classnames2.default)('md-text-field-container', containerClassName, {
+      return _react2.default.createElement('div',
+        _extends({}, remainingProps, {
+          className: (0, _classnames2.default)('md-text-field-container', className, {
             'multi-line': multiline,
             'full-width': fullWidth,
             'with-message': helpText || errorText
           })
-        },
+        }),
         _react2.default.createElement(
           'label',
           { className: 'md-text-field-label' },
@@ -270,7 +311,7 @@ var TextField = function (_Component) {
 
 TextField.propTypes = {
   className: _react.PropTypes.string,
-  containerClassName: _react.PropTypes.string,
+  inputClassName: _react.PropTypes.string,
   children: _react.PropTypes.node,
   type: _react.PropTypes.string.isRequired,
   label: _react.PropTypes.string,
@@ -286,10 +327,17 @@ TextField.propTypes = {
   floatingLabel: _react.PropTypes.bool,
   icon: _react.PropTypes.node,
   rightIcon: _react.PropTypes.node,
-  onFocus: _react.PropTypes.func,
   onBlur: _react.PropTypes.func,
   onChange: _react.PropTypes.func,
+  onFocus: _react.PropTypes.func,
+  onInput: _react.PropTypes.func,
+  onIvalid: _react.PropTypes.func,
+  onKeyDown: _react.PropTypes.func,
+  onKeyPress: _react.PropTypes.func,
+  onKeyUp: _react.PropTypes.func,
+  onSelect: _react.PropTypes.func,
   style: _react.PropTypes.object,
+  inputStyle: _react.PropTypes.object,
   lineDirection: _react.PropTypes.oneOf(['left', 'center', 'right']),
   required: _react.PropTypes.bool,
   fullWidth: _react.PropTypes.bool


### PR DESCRIPTION
**Commit**
* Now className is applied to container instead of input
* containerClassName is removed
* inputClassName is added
* Remaining props is applied to container instead of input
* Input events properties are explicitly applied to input

resolves #26

**Pull Request Notes**
* I changed my opinion regard to `style` and `containerStyle`.

* `style` should be applied to container, because container is the root of the component, such as is applied in the other components. So an `inputStyle` property makes more sense. So the same logic applies to `className` property, therefore I've added an `inputClassName` and removed  `containerClassName`.

Thus `className`, `style` and the remaining properties are applied to container.

Every input property event was explicitly applied to the Input, in addition to the `type` property.

* I improved the modified code, to keep lines with 80 columns, and sorting alphabetically the names of variables.

* If this Pull Request is approved then is necessary to create a new issue to fix the documentation