### PR TITLE
Fix TextField style property

### DIFF
--- a/src/js/TextFields/TextField.js
+++ b/src/js/TextFields/TextField.js
@@ -135,7 +135,6 @@ export default class TextField extends Component {
       lineDirection,
       rows,
       maxRows,
-      style,
       inputStyle,
       required,
       helpOnFocus,


### PR DESCRIPTION
The style property was not properly applied to the container, because was previously filtered in `props`, and the container element is using `{...props}` to get remaining properties.
