### PR TITLE
Fix issue caused by react-docgen

### DIFF
--- a/src/js/Menus/Menu.js
+++ b/src/js/Menus/Menu.js
@@ -74,7 +74,7 @@ export default class Menu extends Component {
     /**
      * The position that the menu should appear from.
      */
-    position: PropTypes.oneOf(Object.keys(Menu.Positions).map(key => Menu.Positions[key])),
+    position: PropTypes.oneOf([ Menu.Positions.TOP_RIGHT, Menu.Positions.TOP_LEFT, Menu.Positions.BOTTOM_RIGHT, Menu.Positions.BOTTOM_LEFT, Menu.Positions.BELOW ]),
 
     /**
      * An optional function that will force the menu to close. This is used so that the

--- a/src/js/SelectFields/SelectField.js
+++ b/src/js/SelectFields/SelectField.js
@@ -129,7 +129,7 @@ export default class SelectField extends Component {
      * SelectField.Positions.BELOW
      * ```
      */
-    position: PropTypes.oneOf(Object.keys(SelectField.Positions).map(key => SelectField.Positions[key])),
+    position: PropTypes.oneOf([ SelectField.Positions.TOP_LEFT, SelectField.Positions.TOP_RIGHT, SelectField.Positions.BELOW ]),
 
     /**
      * Boolean if the drop down menu should not automatically attempt to change the top position to match a


### PR DESCRIPTION
Docgen lazy evaluates the expression in `oneOf` in some cases, for example: in Menu.Positions/SelectFields.Positions:

```js
position: PropTypes.oneOf(Object.keys(Menu.Positions).map(key => Menu.Positions[key])),
```

Gets compiled by docgen to:

```js
"position": {
    "type": "enum",
    "computed": true,
    "value": "Object.keys(Menu.Positions).map(key => Menu.Positions[key])"
}
```
Of course, by the time docgen tries to evaluate `Object.keys(Menu.Positions).map(key => Menu.Positions[key])` later, `Menu.Positions` is undefined, causing the documentation site to error when "Menus" or "Select Fields" is clicked on the documentation site.  When it errors, the page requires to be refreshed completely before it will behave as expected again.