### PR TITLE
Fixed double onChange firing for Switch #182

### DIFF
--- a/src/js/SelectionControls/SwitchThumb.js
+++ b/src/js/SelectionControls/SwitchThumb.js
@@ -16,6 +16,15 @@ export default class SwitchThumb extends PureComponent {
     className: PropTypes.string,
     disabled: PropTypes.bool,
     checked: PropTypes.bool,
+    onClick: PropTypes.func.isRequired,
+  };
+
+  _handleClick = (e) => {
+    // The switch's thumb needs to have an onClick handler to enable keyboard accessibility, however,
+    // this actually triggers two click events since the slider's track needs to be clickable as well.
+    // Stop propagation to prevent the thumb click AND track propagation click.
+    e.stopPropagation();
+    this.props.onClick(e);
   };
 
   render() {
@@ -23,6 +32,7 @@ export default class SwitchThumb extends PureComponent {
     return (
       <AccessibleFakeInkedButton
         {...props}
+        onClick={this._handleClick}
         disabled={disabled}
         disabledInteractions={disabledInteractions}
         inkContainerClassName="md-ink-container--2x"

--- a/src/js/SelectionControls/__tests__/SwitchThumb.js
+++ b/src/js/SelectionControls/__tests__/SwitchThumb.js
@@ -11,15 +11,16 @@ import {
 import SwitchThumb from '../SwitchThumb';
 import AccessibleFakeInkedButton from '../../Helpers/AccessibleFakeInkedButton';
 
+const noop = () => {};
 describe('SwitchThumb', () => {
   it('renders an AccessibleFakeInkedButton', () => {
-    const thumb = renderIntoDocument(<SwitchThumb />);
+    const thumb = renderIntoDocument(<SwitchThumb onClick={noop} />);
     const btns = scryRenderedComponentsWithType(thumb, AccessibleFakeInkedButton);
     expect(btns.length).toBe(1);
   });
 
   it('renders an AccessibleFakeInkedButton with the correct classNames', () => {
-    const props = { disabled: false, checked: false };
+    const props = { disabled: false, checked: false, onClick: noop };
     let thumb = renderIntoDocument(<SwitchThumb {...props} />);
     let btn = findRenderedComponentWithType(thumb, AccessibleFakeInkedButton);
     expect(btn.props.className).toContain('md-switch-thumb');


### PR DESCRIPTION
The switch's thumb and the switch's track need the onClick handler so
that either the track can be clicked or the thumb can be _clicked_ by
pressing the enter key. However, if a user actually touches or clicks
the thumb itself, the click event propigates from the thumb to the track
as well, so two onChange events are emitted.

This commit prevents that click propigation from the switch's thumb.