### PR TITLE
Grid without spacing affects on right aligned cell

### DIFF
--- a/src/scss/_grids.scss
+++ b/src/scss/_grids.scss
@@ -149,7 +149,8 @@ $md-grid-max-columns: $md-grid-desktop-columns !default;
 
       > .md-cell {
         margin: 0;
-        
+
+        // scss-lint:disable NestingDepth
         &.md-cell--right {
           @extend %md-cell--right;
         }

--- a/src/scss/_grids.scss
+++ b/src/scss/_grids.scss
@@ -149,6 +149,10 @@ $md-grid-max-columns: $md-grid-desktop-columns !default;
 
       > .md-cell {
         margin: 0;
+        
+        &.md-cell--right {
+          @extend %md-cell--right;
+        }
       }
     }
   }


### PR DESCRIPTION
Styles of ``md-grid--no-spacing`` should not affect on ``md-cell--right`` ``margin-left: auto;`` attribute.