### PR TITLE
WIP: DataTable with fixed header (vertically scrollable)

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -160,7 +160,7 @@ linters:
 
   SelectorDepth:
     enabled: true
-    max_depth: 3
+    max_depth: 4
 
   SelectorFormat:
     enabled: true

--- a/src/js/DataTables/DataTable.js
+++ b/src/js/DataTables/DataTable.js
@@ -213,6 +213,17 @@ export default class DataTable extends PureComponent {
     delete props.defaultSelectedRows;
     delete props.baseId;
     delete props.onRowToggle;
+    const {
+      width,
+      height,
+      ...style
+    } = props.style || {};
+    delete props.style;
+    if (!responsive) {
+      style.width = width;
+      style.height = height;
+    }
+    props.style = style;
 
     const table = (
       <table
@@ -225,6 +236,14 @@ export default class DataTable extends PureComponent {
       </table>
     );
 
-    return responsive ? <div className="md-data-table--responsive">{table}</div> : table;
+    return responsive ? (
+      <div className="md-data-table--responsive" style={{ width }}>
+        <div className="md-data-table--responsive-header-placeholder">
+          <div className="md-data-table--responsive-vertical-scroll" style={{ height: height - 56 }}>
+            {table}
+          </div>
+        </div>
+      </div>
+    ) : table;
   }
 }

--- a/src/js/DataTables/TableCheckbox.js
+++ b/src/js/DataTables/TableCheckbox.js
@@ -1,17 +1,19 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PureComponent, PropTypes } from 'react';
+import cn from 'classnames';
 import SelectionControl from '../SelectionControls/SelectionControl';
 
 import checkboxContextTypes from './checkboxContextTypes';
 
-export default class TableCheckbox extends Component {
+export default class TableCheckbox extends PureComponent {
   static propTypes = {
     checked: PropTypes.bool,
+    header: PropTypes.bool,
   };
 
   static contextTypes = checkboxContextTypes;
 
   render() {
-    const { checked, ...props } = this.props;
+    const { checked, header, ...props } = this.props;
     const {
       uncheckedIconChildren,
       uncheckedIconClassName,
@@ -21,20 +23,40 @@ export default class TableCheckbox extends Component {
       baseName,
     } = this.context;
 
+    const selectionControl = (
+      <SelectionControl
+        {...props}
+        id={rowId}
+        name={`${baseName}-checkbox`}
+        type="checkbox"
+        checked={checked}
+        uncheckedCheckboxIconChildren={uncheckedIconChildren}
+        uncheckedCheckboxIconClassName={uncheckedIconClassName}
+        checkedCheckboxIconChildren={checkedIconChildren}
+        checkedCheckboxIconClassName={checkedIconClassName}
+      />
+    );
+
+    const _className = cn({ 'md-table-checkbox--header': header });
+
+    let responsiveHelper;
+    if (header) {
+      responsiveHelper = (
+        <div className="md-table-checkbox--responsive-header">
+          <div className={_className}>
+            {selectionControl}
+          </div>
+        </div>
+      );
+    }
+
+    const Component = header ? 'th' : 'td';
+
     return (
-      <td className="md-table-checkbox">
-        <SelectionControl
-          {...props}
-          id={rowId}
-          name={`${baseName}-checkbox`}
-          type="checkbox"
-          checked={checked}
-          uncheckedCheckboxIconChildren={uncheckedIconChildren}
-          uncheckedCheckboxIconClassName={uncheckedIconClassName}
-          checkedCheckboxIconChildren={checkedIconChildren}
-          checkedCheckboxIconClassName={checkedIconClassName}
-        />
-      </td>
+      <Component className={cn('md-table-checkbox', _className)}>
+        {selectionControl}
+        {responsiveHelper}
+      </Component>
     );
   }
 }

--- a/src/js/DataTables/TableColumn.js
+++ b/src/js/DataTables/TableColumn.js
@@ -135,26 +135,38 @@ class TableColumn extends PureComponent {
       );
     }
 
+    const _className = cn({
+      'md-table-column--header': header,
+      'md-table-column--data': !header,
+      'md-table-column--adjusted': adjusted,
+      'md-table-column--sortable md-pointer--hover': sortable,
+      'md-table-column--relative': !__fixedColumn && tooltip,
+      'md-table-column--select-field': selectColumnHeader,
+      'md-text': !header,
+      'md-text--secondary': header,
+      'md-text-left': !numeric,
+      'md-text-right': numeric,
+    }, className);
+
+    let responsiveHelper;
+    if (header) {
+      responsiveHelper = (
+        <div className="md-table-column--responsive-header">
+          <div className={_className}>
+            {tooltip}
+            {displayedChildren}
+          </div>
+        </div>
+      );
+    }
+
     const Component = header ? 'th' : 'td';
 
     return (
-      <Component
-        {...props}
-        className={cn('md-table-column', {
-          'md-table-column--header': header,
-          'md-table-column--data': !header,
-          'md-table-column--adjusted': adjusted,
-          'md-table-column--sortable md-pointer--hover': sortable,
-          'md-table-column--relative': !__fixedColumn && tooltip,
-          'md-table-column--select-field': selectColumnHeader,
-          'md-text': !header,
-          'md-text--secondary': header,
-          'md-text-left': !numeric,
-          'md-text-right': numeric,
-        }, className)}
-      >
+      <Component {...props} className={cn('md-table-column', _className)}>
         {tooltip}
         {displayedChildren}
+        {responsiveHelper}
       </Component>
     );
   }

--- a/src/js/DataTables/TableRow.js
+++ b/src/js/DataTables/TableRow.js
@@ -193,7 +193,14 @@ export default class TableRow extends Component {
 
     let checkbox;
     if (!this.context.plain) {
-      checkbox = <TableCheckbox key="checkbox" checked={selected} onChange={onCheckboxClick} />;
+      checkbox = (
+        <TableCheckbox
+          key="checkbox"
+          checked={selected}
+          header={this.context.header}
+          onChange={onCheckboxClick}
+        />
+      );
     }
 
     const length = children.length;

--- a/src/scss/components/_data-tables.scss
+++ b/src/scss/components/_data-tables.scss
@@ -228,9 +228,53 @@ $md-data-table-card-header-font-size: 16px !default;
 
     &--responsive {
       overflow-x: auto;
+      overflow-y: hidden;
+
+      &-header-placeholder {
+        display: table;
+        padding-top: 56px;
+        position: relative;
+      }
+
+      &-vertical-scroll {
+        overflow-x: hidden;
+        overflow-y: auto;
+      }
 
       .md-data-table {
         width: 100%;
+      }
+
+      tr > .md-table-column--header,
+      tr > .md-table-checkbox--header {
+        height: 0;
+        line-height: 0;
+        padding-bottom: 0;
+        padding-top: 0;
+        visibility: hidden;
+        white-space: nowrap;
+      }
+
+      tr > .md-table-column--header > *,
+      tr > .md-table-checkbox--header > * {
+        display: none;
+      }
+
+      tr > .md-table-column--header > .md-table-column--responsive-header,
+      tr > .md-table-checkbox--header > .md-table-checkbox--responsive-header {
+        display: block;
+        line-height: normal;
+        position: absolute;
+        top: 0;
+        visibility: visible;
+      }
+
+      .md-table-column--responsive-header .md-table-column--header {
+        padding-top: 20px;
+      }
+
+      .md-table-checkbox--responsive-header .md-selection-control-container {
+        height: 56px;
       }
     }
 


### PR DESCRIPTION
*This is a PR for #197.*

Currently, it works fine for simple use-cases: data (with checkboxes) and plain tables without tooltips or editable dialogs or select fields.

How to see it in the works? Just pass `style={{width: 400, height: 300}}` to the DataTable component.

What doesn't work:

* tooltips cause incorrect header position due to `position: relative` added to the `th`
* select fields and edit dialogs jump too much to the left due to `position: relative` used around the DataTable

![screencast-react-md-datatables](https://cloud.githubusercontent.com/assets/304265/21467310/97c1e1c6-c9f1-11e6-90b3-ad68e23562d6.gif)
