### PR TITLE
Portal Components Pass Props Correctly

### DIFF
--- a/src/js/BottomNavigations/BottomNavigation.js
+++ b/src/js/BottomNavigations/BottomNavigation.js
@@ -126,6 +126,12 @@ export default class BottomNavigation extends PureComponent {
     renderNode: PropTypes.object,
 
     /**
+     * Boolean if the bottom navigation should render as the last child in the `renderNode` or `body`
+     * instead of as the first.
+     */
+    lastChild: PropTypes.bool,
+
+    /**
      * The transition duration for the dynamic bottom navigation to appear or disappear. This should
      * match the `$md-bottom-navigation-transition-time` variable.
      */
@@ -291,6 +297,7 @@ export default class BottomNavigation extends PureComponent {
       actions,
       colored,
       dynamic,
+      lastChild,
       renderNode,
       ...props
     } = this.props;
@@ -321,7 +328,7 @@ export default class BottomNavigation extends PureComponent {
     const activeIndex = getField(this.props, this.state, 'activeIndex');
 
     return (
-      <Portal renderNode={renderNode} visible={portalVisible}>
+      <Portal renderNode={renderNode} visible={portalVisible} lastChild={lastChild}>
         <Paper
           {...props}
           className={cn('md-bottom-navigation', {

--- a/src/js/Dialogs/DialogContainer.js
+++ b/src/js/Dialogs/DialogContainer.js
@@ -232,6 +232,14 @@ export default class DialogContainer extends PureComponent {
      */
     renderNode: PropTypes.object,
 
+    /**
+     * Boolean if the dialog should be rendered as the last child in the `renderNode` or `body` instead
+     * of as the first.
+     *
+     * When there are nested dialogs, this prop should be enabled to get correct z-indexes.
+     */
+    lastChild: PropTypes.bool,
+
     isOpen: deprecated(PropTypes.bool, 'Use `visible` instead'),
     transitionName: deprecated(PropTypes.string, 'The transition name will be managed by the component'),
     transitionEnter: deprecated(PropTypes.bool, 'The transition will always be enforced'),
@@ -411,6 +419,7 @@ export default class DialogContainer extends PureComponent {
       transitionEnterTimeout,
       transitionLeaveTimeout,
       renderNode,
+      lastChild,
       ...props
     } = this.props;
     delete props.close;
@@ -440,7 +449,7 @@ export default class DialogContainer extends PureComponent {
     );
 
     return (
-      <Portal visible={portalVisible} renderNode={renderNode}>
+      <Portal visible={portalVisible} renderNode={renderNode} lastChild={lastChild}>
         <CSSTransitionGroup
           component={component}
           ref={this._setContainer}

--- a/src/js/Drawers/Drawer.js
+++ b/src/js/Drawers/Drawer.js
@@ -190,9 +190,21 @@ export default class Drawer extends PureComponent {
 
     /**
      * An optional DOM Node to render the drawer into. The default is to render as
-     * the last child in the `body`.
+     * the first child in the `body`.
+     *
+     * > This prop will not be used when the drawer is of the permanent type or `inline` is specified
+     * since the `Portal` component will not be used.
      */
     renderNode: PropTypes.object,
+
+    /**
+     * Boolean if the drawer should be rendered as the last child instead of the first child
+     * in the `renderNode` or `body`.
+     *
+     * > This prop will not be used when the drawer is of the permanent type or `inline` is specified
+     * since the `Portal` component will not be used.
+     */
+    lastChild: PropTypes.bool,
 
     /**
      * Boolean if the drawer is visible by default. If this is omitted, the drawer will be visible
@@ -518,6 +530,7 @@ export default class Drawer extends PureComponent {
       overlay,
       autoclose,
       clickableDesktopOverlay,
+      lastChild,
       ...props
     } = this.props;
     delete props.visible;
@@ -619,7 +632,7 @@ export default class Drawer extends PureComponent {
     }
 
     return (
-      <Portal visible={mini || animating || visible} renderNode={renderNode}>
+      <Portal visible={mini || animating || visible} renderNode={renderNode} lastChild={lastChild}>
         {drawer}
       </Portal>
     );

--- a/src/js/Helpers/Portal.js
+++ b/src/js/Helpers/Portal.js
@@ -45,7 +45,7 @@ export default class Portal extends PureComponent {
 
     /**
      * An optional DOM Node to render the portal into. The default is to render as
-     * the last child in the `body`.
+     * the first child in the `body`.
      */
     renderNode: PropTypes.object,
 

--- a/src/js/NavigationDrawers/NavigationDrawer.js
+++ b/src/js/NavigationDrawers/NavigationDrawer.js
@@ -340,12 +340,6 @@ export default class NavigationDrawer extends PureComponent {
     desktopMinWidth: PropTypes.number.isRequired,
 
     /**
-     * An optional DOM Node to render the portal into. The default is to render as
-     * the last child in the `body`.
-     */
-    renderNode: PropTypes.object,
-
-    /**
      * An optional function to call when the type of the drawer changes because of the
      * new media queries. The callback will include the newly selected drawer type
      * and an object containing the media matches of `mobile`, `tablet`, and `desktop`.
@@ -557,6 +551,24 @@ export default class NavigationDrawer extends PureComponent {
      * the main content. This is created in the drawer's header.
      */
     jumpLabel: PropTypes.string.isRequired,
+
+    /**
+     * An optional DOM Node to render the drawer into. The default is to render as
+     * the first child in the `body`.
+     *
+     * > This prop will not be used when the drawer is of the permanent type or `inline` is specified
+     * since the `Portal` component will not be used.
+     */
+    renderNode: PropTypes.object,
+
+    /**
+     * Boolean if the drawer should be rendered as the last child instead of the first child
+     * in the `renderNode` or `body`.
+     *
+     * > This prop will not be used when the drawer is of the permanent type or `inline` is specified
+     * since the `Portal` component will not be used.
+     */
+    lastChild: PropTypes.bool,
 
     menuIconChildren: deprecated(PropTypes.node, 'Use `temporaryIconChildren` instead'),
     menuIconClassName: deprecated(PropTypes.string, 'Use `temporaryIconClassName` instead'),

--- a/src/js/Pickers/DatePickerContainer.js
+++ b/src/js/Pickers/DatePickerContainer.js
@@ -289,6 +289,19 @@ export default class DatePickerContainer extends PureComponent {
      */
     closeOnEsc: PropTypes.bool,
 
+    /**
+     * An optional DOM Node to render the dialog into. The default is to render as the first child
+     * in the `body`.
+     */
+    renderNode: PropTypes.object,
+
+    /**
+     * Boolean if the dialog should be rendered as the last child of the `renderNode` or `body` instead
+     * of the first.
+     *
+     * When the `DatePicker` is nested in a `Dialog`, this prop should be enabled to get the correct z-indexing.
+     */
+    lastChild: PropTypes.bool,
     previousIcon: deprecated(PropTypes.node, 'Use `previousIconChildren` and `previousIconClassName` instead'),
     nextIcon: deprecated(PropTypes.node, 'Use `nextIconChildren` and `nextIconClassName` instead'),
     adjustMinWidth: deprecated(PropTypes.bool, 'No longer valid for a text field'),
@@ -636,6 +649,8 @@ export default class DatePickerContainer extends PureComponent {
       id,
       disabled,
       closeOnEsc,
+      renderNode,
+      lastChild,
       'aria-label': ariaLabel,
       isOpen, // deprecated
       ...props
@@ -689,6 +704,8 @@ export default class DatePickerContainer extends PureComponent {
           contentClassName="md-dialog-content--picker"
           aria-label={ariaLabel}
           closeOnEsc={closeOnEsc}
+          renderNode={renderNode}
+          lastChild={lastChild}
           focusOnMount={false}
         >
           {picker}

--- a/src/js/Pickers/TimePickerContainer.js
+++ b/src/js/Pickers/TimePickerContainer.js
@@ -206,6 +206,19 @@ export default class TimePickerContainer extends PureComponent {
      */
     closeOnEsc: PropTypes.bool,
 
+    /**
+     * An optional DOM Node to render the dialog into. The default is to render as the first child
+     * in the `body`.
+     */
+    renderNode: PropTypes.object,
+
+    /**
+     * Boolean if the dialog should be rendered as the last child of the `renderNode` or `body` instead
+     * of the first.
+     *
+     * When the `TimePicker` is nested in a `Dialog`, this prop should be enabled to get the correct z-indexing.
+     */
+    lastChild: PropTypes.bool,
     isOpen: deprecated(PropTypes.bool, 'Use `visible` instead'),
     initiallyOpen: deprecated(PropTypes.bool, 'Use `defaultVisible` instead'),
     initialTimeMode: deprecated(PropTypes.oneOf(['hour', 'minute']), 'Use `defaultTimeMode` instead'),
@@ -433,6 +446,8 @@ export default class TimePickerContainer extends PureComponent {
       fullWidth,
       lineDirection,
       closeOnEsc,
+      renderNode,
+      lastChild,
       'aria-label': ariaLabel,
       ...props
     } = this.props;
@@ -485,6 +500,8 @@ export default class TimePickerContainer extends PureComponent {
           contentClassName="md-dialog-content--picker"
           aria-label={ariaLabel}
           closeOnEsc={closeOnEsc}
+          lastChild={lastChild}
+          renderNode={renderNode}
           focusOnMount={false}
         >
           {picker}

--- a/src/js/Snackbars/SnackbarContainer.js
+++ b/src/js/Snackbars/SnackbarContainer.js
@@ -137,7 +137,18 @@ export default class SnackbarContainer extends PureComponent {
 
       return null;
     },
+
+    /**
+     * An optional DOM node to render the Snackbar in. If this is omitted, it will render as the first
+     * child in the `body`.
+     */
     renderNode: PropTypes.object,
+
+    /**
+     * Boolean if the snackbar should render as the last child in the `renderNode` or `body` instead of
+     * as the first.
+     */
+    lastChild: PropTypes.bool,
     dismiss: deprecated(PropTypes.func, 'Use `onDismiss` instead'),
   };
 
@@ -291,6 +302,7 @@ export default class SnackbarContainer extends PureComponent {
       transitionLeaveTimeout,
       dismiss,
       onDismiss,
+      lastChild,
       renderNode,
       ...props
     } = this.props;
@@ -311,7 +323,7 @@ export default class SnackbarContainer extends PureComponent {
     }
 
     return (
-      <Portal visible={visible} renderNode={renderNode}>
+      <Portal visible={visible} renderNode={renderNode} lastChild={lastChild}>
         <CSSTransitionGroup
           ref={this._setContainer}
           key="container"


### PR DESCRIPTION
Updated all the components that use the Portal component to correctly
pass the `lastChild` and `renderNode` to the nested Portal. This should
close #229.
