### PR TITLE
Fixed active label update condition on SelectField

### DIFF
--- a/src/js/SelectFields/SelectField.js
+++ b/src/js/SelectFields/SelectField.js
@@ -365,7 +365,7 @@ export default class SelectField extends PureComponent {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.value !== nextProps.value) {
+    if (this.props.value !== nextProps.value || this.props.menuItems !== nextProps.menuItems) {
       this.setState({ activeLabel: this._getActiveLabel(nextProps, nextProps.value) });
     }
   }


### PR DESCRIPTION
*I am not absolutely sure if this is a bug or a feature, but it doesn't play as I would expect, so I propose this patch.*

`value` may stay unchanged while the list of available options changes in which case active label should be updated.