### PR TITLE
Implemented Dense Icons

### DIFF
--- a/docs/src/client/_styles.scss
+++ b/docs/src/client/_styles.scss
@@ -75,3 +75,9 @@ $md-badge-include-default: true;
 .powerlevel-over-9000 {
   z-index: 9001;
 }
+
+@media #{$md-desktop-media} {
+  .fa.md-icon {
+    font-size: $md-font-icon-dense-size;
+  }
+}

--- a/docs/src/shared/components/PhoneSizeDemo/_phone-size.scss
+++ b/docs/src/shared/components/PhoneSizeDemo/_phone-size.scss
@@ -207,6 +207,33 @@ $phone-status-bar-height: 24px;
       font-size: $md-title-font-size;
     }
 
+    .md-icon {
+      font-size: $md-font-icon-size;
+
+      &--tab {
+        margin-bottom: 10px;
+        margin-top: 0;
+      }
+    }
+
+    .md-btn--icon {
+      height: $md-btn-icon-size;
+      padding: $md-btn-icon-padding;
+      width: $md-btn-icon-size;
+    }
+
+    .md-btn--floating {
+      height: $md-btn-floating-size;
+      padding: ($md-btn-floating-size - $md-font-icon-size) / 2;
+      width: $md-btn-floating-size;
+
+      &-mini {
+        height: $md-btn-floating-mini-size;
+        padding: ($md-btn-floating-mini-size - $md-font-icon-size) / 2;
+        width: $md-btn-floating-mini-size;
+      }
+    }
+
     .md-btn--fixed-tl {
       top: $md-toolbar-mobile-prominent-height;
     }

--- a/docs/src/shared/components/ReactMD/buttons/README.md
+++ b/docs/src/shared/components/ReactMD/buttons/README.md
@@ -4,6 +4,10 @@ There are four types of buttons in react-md:
 - icon
 - floating
 
+Starting from v1.1.0, the dense spec for icons has been implemented. This means that the icon and floating buttons
+will be smaller when matching the destkop media query than when on mobile devices. See the
+[dense spec variable](/components/font-icons?tab=2#variable-md-font-icon-include-dense) for more information.
+
 All of these types can be styled using the primary, secondary, or theme's colors. `flat` and `icon` buttons
 will theme the text color in the button while `raised` and `floating` will theme the background of the button.
 

--- a/docs/src/shared/components/ReactMD/font-icons/README.md
+++ b/docs/src/shared/components/ReactMD/font-icons/README.md
@@ -1,3 +1,9 @@
 The `FontIcon` component is used to render different font libraries
 with the material design specs. The default font icon library used
 is the Material Icons.
+
+Starting from v1.1.0, a dense spec has been added to icons. This will
+automatically reduce the icon size from `24px` to `20px` when viewing
+the website when the desktop media query matches. This behavior can be
+disabled by setting `$md-font-icon-include-dense` to `false` if this is
+not desired behavior.

--- a/docs/src/shared/components/ReactMD/helpers/icon-separator/_icon-separators.scss
+++ b/docs/src/shared/components/ReactMD/helpers/icon-separator/_icon-separators.scss
@@ -10,3 +10,9 @@
     width: $md-font-icon-size;
   }
 }
+
+@media #{$md-desktop-media} {
+  .separator-examples .md-icon-separator .md-icon {
+    width: $md-font-icon-dense-size;
+  }
+}

--- a/src/scss/_typography.scss
+++ b/src/scss/_typography.scss
@@ -158,6 +158,11 @@ $md-caption-font-size: 12px !default;
 /// @group icons
 $md-font-icon-size: 24px !default;
 
+/// The dense font icon size
+/// @type Number
+/// @group icons
+$md-font-icon-dense-size: 20px !default;
+
 /// The line height to use on almost all elements.
 /// @type Number
 $md-line-height: 20 / $md-font-size-base !default;

--- a/src/scss/components/_buttons.scss
+++ b/src/scss/components/_buttons.scss
@@ -86,6 +86,14 @@ $md-btn-icon-size: $md-font-icon-size * 2 !default;
 /// @type Number
 $md-btn-icon-padding: $md-btn-icon-size / 4 !default;
 
+/// The size for a icon button when using the dense spec.
+/// @type Number
+$md-btn-icon-dense-size: $md-font-icon-dense-size * 2 !default;
+
+/// The padding to use for a dense icon button.
+/// @type Number
+$md-btn-icon-dense-padding: $md-btn-icon-dense-size / 4 !default;
+
 /// The base color to use for default buttons in the light theme.
 /// @type Color
 $md-btn-light-theme-base-color: #999 !default;
@@ -143,6 +151,8 @@ $md-btn-dark-theme-pressed-color: rgba($md-btn-dark-theme-base-color, .25) !defa
 ///     buttons should be included.
 /// @param {Boolean} include-floating [$md-btn-include-floating] - Boolean if the floating styles for
 ///     buttons should be included.
+/// @param {Boolean} include-dense [$md-font-icon-include-dense] - Boolean if the dense specs for icons
+///     should be included for buttons.
 @mixin react-md-buttons(
   $primary-color: $md-primary-color,
   $secondary-color: $md-secondary-color,
@@ -151,12 +161,9 @@ $md-btn-dark-theme-pressed-color: rgba($md-btn-dark-theme-base-color, .25) !defa
   $include-flat: $md-btn-include-flat,
   $include-raised: $md-btn-include-raised,
   $include-icon: $md-btn-include-icon,
-  $include-floating: $md-btn-include-floating
+  $include-floating: $md-btn-include-floating,
+  $include-dense: $md-font-icon-include-dense
 ) {
-  @if $include-media {
-    @include react-md-buttons-media($include-flat, $include-raised);
-  }
-
   // scss-lint:disable QualifyingElement
   a.md-btn {
     text-decoration: none;
@@ -264,6 +271,10 @@ $md-btn-dark-theme-pressed-color: rgba($md-btn-dark-theme-base-color, .25) !defa
       position: fixed;
       z-index: $md-btn-fixed-z-index;
     }
+  }
+
+  @if $include-media {
+    @include react-md-buttons-media($include-flat, $include-raised, $include-dense);
   }
 }
 
@@ -408,8 +419,10 @@ $md-btn-dark-theme-pressed-color: rgba($md-btn-dark-theme-base-color, .25) !defa
 ///     buttons should be included.
 /// @param {Boolean} include-floating [$md-btn-include-floating] - Boolean if the floating styles for
 ///     buttons should be included.
+/// @param {Boolean} include-dense [$md-font-icon-include-dense] - Boolean if the dense specs for icons
+///     should be included for buttons.
 /// @group buttons, media-queries
-@mixin react-md-buttons-desktop($include-flat: $md-btn-include-flat, $include-raised: $md-btn-include-raised, $include-floating: $md-btn-include-floating) {
+@mixin react-md-buttons-desktop($include-flat: $md-btn-include-flat, $include-raised: $md-btn-include-raised, $include-icon: $md-btn-include-icon, $include-floating: $md-btn-include-floating, $include-dense: $md-font-icon-include-dense) {
   @if $include-flat or $include-raised {
     .md-btn--text {
       font-size: $md-btn-desktop-font-size;
@@ -454,6 +467,14 @@ $md-btn-dark-theme-pressed-color: rgba($md-btn-dark-theme-base-color, .25) !defa
       left: $md-btn-desktop-floating-margin;
     }
   }
+
+  @if ($include-icon or $include-floating) and $include-dense {
+    .md-btn--icon {
+      height: $md-btn-icon-dense-size;
+      padding: $md-btn-icon-dense-padding;
+      width: $md-btn-icon-dense-size;
+    }
+  }
 }
 
 /// Creates the media queries and styles for buttons for mobile and desktop.
@@ -467,8 +488,15 @@ $md-btn-dark-theme-pressed-color: rgba($md-btn-dark-theme-base-color, .25) !defa
 ///     buttons should be included.
 /// @param {Boolean} include-floating [$md-btn-include-floating] - Boolean if the floating styles for
 ///     buttons should be included.
+/// @param {Boolean} include-dense [$md-font-icon-include-dense] - Boolean if the dense specs for icons
+///     should be included for buttons.
 /// @group buttons, media-queries
-@mixin react-md-buttons-media($include-flat: $md-btn-include-flat, $include-raised: $md-btn-include-raised, $include-floating: $md-btn-include-floating) {
+@mixin react-md-buttons-media(
+  $include-flat: $md-btn-include-flat,
+  $include-raised: $md-btn-include-raised,
+  $include-floating: $md-btn-include-floating,
+  $include-dense: $md-font-icon-include-dense
+) {
   @media #{$md-mobile-media} {
     @include react-md-buttons-mobile($include-flat, $include-raised, $include-floating);
   }

--- a/src/scss/components/_buttons.scss
+++ b/src/scss/components/_buttons.scss
@@ -74,6 +74,10 @@ $md-btn-min-width: 88px !default;
 /// @type Number
 $md-btn-floating-size: 56px !default;
 
+/// The size for a floating button when using the dense spec for icons.
+/// @type Number
+$md-btn-floating-dense-size: 48px !default;
+
 /// The the mini size for a floating button.
 /// @type Number
 $md-btn-floating-mini-size: 40px !default;
@@ -151,7 +155,7 @@ $md-btn-dark-theme-pressed-color: rgba($md-btn-dark-theme-base-color, .25) !defa
 ///     buttons should be included.
 /// @param {Boolean} include-floating [$md-btn-include-floating] - Boolean if the floating styles for
 ///     buttons should be included.
-/// @param {Boolean} include-dense [$md-font-icon-include-dense] - Boolean if the dense specs for icons
+/// @param {Boolean} include-dense-icons [$md-font-icon-include-dense] - Boolean if the dense specs for icons
 ///     should be included for buttons.
 @mixin react-md-buttons(
   $primary-color: $md-primary-color,
@@ -162,7 +166,7 @@ $md-btn-dark-theme-pressed-color: rgba($md-btn-dark-theme-base-color, .25) !defa
   $include-raised: $md-btn-include-raised,
   $include-icon: $md-btn-include-icon,
   $include-floating: $md-btn-include-floating,
-  $include-dense: $md-font-icon-include-dense
+  $include-dense-icons: $md-font-icon-include-dense
 ) {
   // scss-lint:disable QualifyingElement
   a.md-btn {
@@ -274,7 +278,7 @@ $md-btn-dark-theme-pressed-color: rgba($md-btn-dark-theme-base-color, .25) !defa
   }
 
   @if $include-media {
-    @include react-md-buttons-media($include-flat, $include-raised, $include-dense);
+    @include react-md-buttons-media($include-flat, $include-raised, $include-icon, $include-floating, $include-dense-icons);
   }
 }
 
@@ -417,12 +421,20 @@ $md-btn-dark-theme-pressed-color: rgba($md-btn-dark-theme-base-color, .25) !defa
 ///     buttons should be included.
 /// @param {Boolean} include-raised [$md-btn-include-raised] - Boolean if the raised styles for
 ///     buttons should be included.
+/// @param {Boolean} include-icon [$md-btn-include-icon] - Boolean if the icon styles for
+///     buttons should be included.
 /// @param {Boolean} include-floating [$md-btn-include-floating] - Boolean if the floating styles for
 ///     buttons should be included.
-/// @param {Boolean} include-dense [$md-font-icon-include-dense] - Boolean if the dense specs for icons
+/// @param {Boolean} include-dense-icons [$md-font-icon-include-dense] - Boolean if the dense specs for icons
 ///     should be included for buttons.
 /// @group buttons, media-queries
-@mixin react-md-buttons-desktop($include-flat: $md-btn-include-flat, $include-raised: $md-btn-include-raised, $include-icon: $md-btn-include-icon, $include-floating: $md-btn-include-floating, $include-dense: $md-font-icon-include-dense) {
+@mixin react-md-buttons-desktop(
+  $include-flat: $md-btn-include-flat,
+  $include-raised: $md-btn-include-raised,
+  $include-icon: $md-btn-include-icon,
+  $include-floating: $md-btn-include-floating,
+  $include-dense-icons: $md-font-icon-include-dense
+) {
   @if $include-flat or $include-raised {
     .md-btn--text {
       font-size: $md-btn-desktop-font-size;
@@ -468,11 +480,23 @@ $md-btn-dark-theme-pressed-color: rgba($md-btn-dark-theme-base-color, .25) !defa
     }
   }
 
-  @if ($include-icon or $include-floating) and $include-dense {
+  @if ($include-icon or $include-floating) and $include-dense-icons {
     .md-btn--icon {
       height: $md-btn-icon-dense-size;
       padding: $md-btn-icon-dense-padding;
       width: $md-btn-icon-dense-size;
+    }
+
+    .md-btn--floating {
+      height: $md-btn-floating-dense-size;
+      padding: ($md-btn-floating-dense-size - $md-font-icon-dense-size) / 2;
+      width: $md-btn-floating-dense-size;
+
+      &-mini {
+        height: $md-btn-floating-mini-size;
+        padding: ($md-btn-floating-mini-size - $md-font-icon-dense-size) / 2;
+        width: $md-btn-floating-mini-size;
+      }
     }
   }
 }
@@ -486,22 +510,25 @@ $md-btn-dark-theme-pressed-color: rgba($md-btn-dark-theme-base-color, .25) !defa
 ///     buttons should be included.
 /// @param {Boolean} include-raised [$md-btn-include-raised] - Boolean if the raised styles for
 ///     buttons should be included.
+/// @param {Boolean} include-icon [$md-btn-include-icon] - Boolean if the icon styles for
+///     buttons should be included.
 /// @param {Boolean} include-floating [$md-btn-include-floating] - Boolean if the floating styles for
 ///     buttons should be included.
-/// @param {Boolean} include-dense [$md-font-icon-include-dense] - Boolean if the dense specs for icons
+/// @param {Boolean} include-dense-icons [$md-font-icon-include-dense] - Boolean if the dense specs for icons
 ///     should be included for buttons.
 /// @group buttons, media-queries
 @mixin react-md-buttons-media(
   $include-flat: $md-btn-include-flat,
   $include-raised: $md-btn-include-raised,
+  $include-icon: $md-btn-include-icon,
   $include-floating: $md-btn-include-floating,
-  $include-dense: $md-font-icon-include-dense
+  $include-dense-icons: $md-font-icon-include-dense
 ) {
   @media #{$md-mobile-media} {
     @include react-md-buttons-mobile($include-flat, $include-raised, $include-floating);
   }
 
   @media #{$md-desktop-media} {
-    @include react-md-buttons-desktop($include-flat, $include-raised, $include-floating);
+    @include react-md-buttons-desktop($include-flat, $include-raised, $include-icon, $include-floating, $include-dense-icons);
   }
 }

--- a/src/scss/components/_chips.scss
+++ b/src/scss/components/_chips.scss
@@ -57,6 +57,11 @@ $md-chip-avatar-left-padding: 8px !default;
 /// @type Number
 $md-chip-icon-padding: 4px !default;
 
+/// The amount of padding to use around the remove icon on a chip when using the dense
+/// icon spec.
+/// @type Number
+$md-chip-icon-dense-padding: 6px !default;
+
 /// The font size for a contact chip.
 /// @type Number
 $md-chip-contact-font-size: 14px !default;
@@ -68,13 +73,26 @@ $md-chip-contact-font-size: 14px !default;
 /// @example scss - Example Usage SCSS
 ///   include react-md-chips;
 ///
+/// @param {Boolean} light-theme [$md-light-theme] - Boolean if the chips should be themed for
+///     the light theme.
+/// @param {Boolean} include-media [$md-media-included] - Boolean if the media queries for chips
+///     should be included. This really relies on the `include-dense-icons` as well.
 /// @param {Boolean} include-remove [$md-chip-include-remove] - Boolean if the remove styles
 ///     should be included.
 /// @param {Boolean} include-avatar [$md-chip-include-avatar] - Boolean if the avatar styles
 ///     should be included.
 /// @param {Boolean} include-contact [$md-chip-include-contact] - Boolean if the contact styles
 ///     should be included.
-@mixin react-md-chips($light-theme: $md-light-theme, $include-remove: $md-chip-include-remove, $include-avatar: $md-chip-include-avatar, $include-contact: $md-chip-include-contact) {
+/// @param {Boolean} include-dense-icons [$md-font-icon-include-dense] - Boolean if the dense spec for
+///     icons should be included with the remove icon.
+@mixin react-md-chips(
+  $light-theme: $md-light-theme,
+  $include-media: $md-media-included,
+  $include-remove: $md-chip-include-remove,
+  $include-avatar: $md-chip-include-avatar,
+  $include-contact: $md-chip-include-contact,
+  $include-dense-icons: $md-font-icon-include-dense
+) {
   .md-chip {
     align-items: center;
     background: if($light-theme, $md-chip-light-theme-bg-color, $md-chip-dark-theme-bg-color);
@@ -122,6 +140,16 @@ $md-chip-contact-font-size: 14px !default;
   // has to go last so it has higher precidence.
   .md-chip-text--hover {
     color: $md-white-base;
+  }
+
+  @if $include-media and $include-remove and $include-dense-icons {
+    @media #{$md-desktop-media} {
+      .md-chip-icon {
+        margin-left: $md-chip-icon-dense-padding;
+        margin-right: $md-chip-icon-dense-padding;
+        top: ($md-chip-height - $md-font-icon-dense-size) / 2;
+      }
+    }
   }
 }
 

--- a/src/scss/components/_icons.scss
+++ b/src/scss/components/_icons.scss
@@ -6,6 +6,11 @@
 /// @type Boolean
 $md-font-icon-include-separators: true !default;
 
+/// Boolean if the dense spec for icons should be included. This will
+/// update the size for icons to be smaller on desktop displays.
+/// @type Boolean
+$md-font-icon-include-dense: true !default;
+
 /// The amount of padding to put between an icon and any text.
 /// @type Number
 $md-font-icon-separator-padding: $md-default-padding !default;
@@ -21,7 +26,7 @@ $md-font-icon-dark-theme-disabled-color: rgba($md-white-base, .3) !default;
 /// Includes the css for using `md-icon`.
 /// @param {Boolean} $light-theme [$md-light-theme] - Boolean if the
 ///     application is using the light-theme or not.
-@mixin react-md-icons($light-theme: $md-light-theme, $include-separators: $md-font-icon-include-separators) {
+@mixin react-md-icons($light-theme: $md-light-theme, $include-media: $md-media-included, $include-separators: $md-font-icon-include-separators, $include-dense: $md-font-icon-include-dense) {
   $md-icon-color: if($light-theme, $md-light-theme-secondary-text-color, $md-dark-theme-secondary-text-color);
 
   .md-icon {
@@ -43,6 +48,32 @@ $md-font-icon-dark-theme-disabled-color: rgba($md-white-base, .3) !default;
 
   @if $include-separators {
     @include react-md-icon-separators;
+  }
+
+  @if $include-media {
+    @include react-md-icons-media($include-dense);
+  }
+}
+
+/// Updates the styles for an icon to use the dense font size. This should really only
+/// be used within a media query.
+@mixin react-md-icons-dense {
+  .md-icon {
+    font-size: $md-font-icon-dense-size;
+  }
+}
+
+/// Creates the media queries for icons. This really only is used for the dense
+/// spec of icons.
+///
+/// @param {Boolean} include-dense [$md-font-icon-include-dense] - Boolean if the dense
+///   specs for icons shoul be included.
+/// @group media-queries, icons
+@mixin react-md-icons-media($include-dense: $md-font-icon-include-dense) {
+  @if $include-dense {
+    @media #{$md-desktop-media} {
+      @include react-md-icons-dense;
+    }
   }
 }
 

--- a/src/scss/components/_icons.scss
+++ b/src/scss/components/_icons.scss
@@ -24,9 +24,21 @@ $md-font-icon-light-theme-disabled-color: rgba($md-black-base, .26) !default;
 $md-font-icon-dark-theme-disabled-color: rgba($md-white-base, .3) !default;
 
 /// Includes the css for using `md-icon`.
-/// @param {Boolean} $light-theme [$md-light-theme] - Boolean if the
-///     application is using the light-theme or not.
-@mixin react-md-icons($light-theme: $md-light-theme, $include-media: $md-media-included, $include-separators: $md-font-icon-include-separators, $include-dense: $md-font-icon-include-dense) {
+///
+/// @param {Boolean} $light-theme [$md-light-theme] - Boolean if the application is using the
+///     light-theme or not.
+/// @param {Boolean} include-media [$md-media-included] - Boolean if the media queries for icons
+///     should also be included. This also relies on the `include-dense` param.
+/// @param {Boolean} include-separators [$md-font-icon-include-separators] - Boolean if the styles
+///     for separating content and an icon should be included.
+/// @param {Boolean} include-dense [$md-font-icon-include-dense] - Boolean if the dense spec for icons
+///     should be included.
+@mixin react-md-icons(
+  $light-theme: $md-light-theme,
+  $include-media: $md-media-included,
+  $include-separators: $md-font-icon-include-separators,
+  $include-dense: $md-font-icon-include-dense
+) {
   $md-icon-color: if($light-theme, $md-light-theme-secondary-text-color, $md-dark-theme-secondary-text-color);
 
   .md-icon {

--- a/src/scss/components/_lists.scss
+++ b/src/scss/components/_lists.scss
@@ -122,6 +122,8 @@ $md-list-desktop-three-lines-height: 76px !default;
 ///     lists with three lines of text should be included.
 /// @param {Boolean} include-controls [$md-list-include-controls] - Boolean if the styles for lists
 ///     with controls to be included.
+/// @param {Boolean} include-unstyled [$md-list-include-unstyled-class-name] - Boolean if the `.md-list-unstyled`
+///     class name should also be generated.
 /// @param {Boolean} include-dense-icons [$md-font-icon-include-dense] - Boolean if the dense styles
 ///     for icons should be included.
 @mixin react-md-lists(

--- a/src/scss/components/_lists.scss
+++ b/src/scss/components/_lists.scss
@@ -122,6 +122,8 @@ $md-list-desktop-three-lines-height: 76px !default;
 ///     lists with three lines of text should be included.
 /// @param {Boolean} include-controls [$md-list-include-controls] - Boolean if the styles for lists
 ///     with controls to be included.
+/// @param {Boolean} include-dense-icons [$md-font-icon-include-dense] - Boolean if the dense styles
+///     for icons should be included.
 @mixin react-md-lists(
   $light-theme: $md-light-theme,
   $nested-items-depth: $md-list-nested-items-depth,
@@ -132,12 +134,9 @@ $md-list-desktop-three-lines-height: 76px !default;
   $include-two-lines: $md-list-include-two-lines,
   $include-three-lines: $md-list-include-three-lines,
   $include-controls: $md-list-include-controls,
-  $include-unstyled: $md-list-include-unstyled-class-name
+  $include-unstyled: $md-list-include-unstyled-class-name,
+  $include-dense-icons: $md-font-icon-include-dense
 ) {
-  @if $include-media {
-    @include react-md-lists-media($include-icon, $include-avatar, $include-two-lines, $include-three-lines);
-  }
-
   @if $include-unstyled {
     .md-list-unstyled {
       @extend %md-list-unstyled;
@@ -286,6 +285,10 @@ $md-list-desktop-three-lines-height: 76px !default;
       padding-right: 0;
     }
   }
+
+  @if $include-media {
+    @include react-md-lists-media($include-icon, $include-avatar, $include-two-lines, $include-three-lines, $include-dense-icons);
+  }
 }
 
 /// Updates the theme for lists ONLY if the `$light-theme` does not equal the `$md-light-theme`.
@@ -396,12 +399,15 @@ $md-list-desktop-three-lines-height: 76px !default;
 ///     lists with two lines of text should be included.
 /// @param {Boolean} include-three-lines [$md-list-include-three-lines] - Boolean if the styles for
 ///     lists with three lines of text should be included.
+/// @param {Boolean} include-dense-icons [$md-font-icon-include-dense] - Boolean if the dense styles
+///     for icons should be included.
 /// @group lists, media-queries
 @mixin react-md-lists-desktop(
   $include-icon: $md-list-include-icon,
   $include-avatar: $md-list-include-avatar,
   $include-two-lines: $md-list-include-two-lines,
-  $include-three-lines: $md-list-include-three-lines
+  $include-three-lines: $md-list-include-three-lines,
+  $include-dense-icons: $md-font-icon-include-dense
 ) {
   .md-list {
     padding-bottom: $md-list-desktop-padding;
@@ -453,6 +459,16 @@ $md-list-desktop-three-lines-height: 76px !default;
       }
     }
   }
+
+  @if $include-dense-icons and $include-icon {
+    .md-tile-addon--icon {
+      height: $md-font-icon-dense-size;
+    }
+
+    .md-tile-content--left-icon {
+      padding-left: $md-list-left-padding - $md-font-icon-dense-size - $md-default-padding;
+    }
+  }
 }
 
 /// Includes the media queries and styles for lists on mobile devices and desktop screens.
@@ -468,19 +484,22 @@ $md-list-desktop-three-lines-height: 76px !default;
 ///     lists with two lines of text should be included.
 /// @param {Boolean} include-three-lines [$md-list-include-three-lines] - Boolean if the styles for
 ///     lists with three lines of text should be included.
+/// @param {Boolean} include-dense-icons [$md-font-icon-include-dense] - Boolean if the dense styles
+///     for icons should be included.
 /// @group lists, media-queries
 @mixin react-md-lists-media(
   $include-icon: $md-list-include-icon,
   $include-avatar: $md-list-include-avatar,
   $include-two-lines: $md-list-include-two-lines,
-  $include-three-lines: $md-list-include-three-lines
+  $include-three-lines: $md-list-include-three-lines,
+  $include-dense-icons: $md-font-icon-include-dense
 ) {
   @media #{$md-mobile-media} {
     @include react-md-lists-mobile($include-icon, $include-avatar, $include-two-lines, $include-three-lines);
   }
 
   @media #{$md-desktop-media} {
-    @include react-md-lists-desktop($include-icon, $include-avatar, $include-two-lines, $include-three-lines);
+    @include react-md-lists-desktop($include-icon, $include-avatar, $include-two-lines, $include-three-lines, $include-dense-icons);
   }
 }
 

--- a/src/scss/components/_tabs.scss
+++ b/src/scss/components/_tabs.scss
@@ -115,7 +115,8 @@ $md-tab-desktop-padding: 24px !default;
   $include-prominent-toolbars: $md-tab-include-prominent-toolbars,
   $include-pagination-overflow: $md-tab-include-pagination-overflow,
   $include-menu-overflow: $md-tab-include-menu-overflow,
-  $include-swipeable: $md-tab-include-swipeable
+  $include-swipeable: $md-tab-include-swipeable,
+  $include-dense-icons: $md-font-icon-include-dense
 ) {
   .md-tabs {
     @extend %md-list-unstyled;
@@ -164,7 +165,7 @@ $md-tab-desktop-padding: 24px !default;
 
 
   @if $include-media {
-    @include react-md-tabs-media($include-icons, $include-toolbars, $include-prominent-toolbars, $include-swipeable);
+    @include react-md-tabs-media($include-icons, $include-toolbars, $include-prominent-toolbars, $include-swipeable, $include-dense-icons);
   }
 }
 
@@ -464,7 +465,7 @@ $md-tab-desktop-padding: 24px !default;
 
 /// Includes the styles for tabs on desktop screens.
 /// @group tabs, media-queries
-@mixin react-md-tabs-desktop {
+@mixin react-md-tabs-desktop($include-icons: $md-tab-include-icons, $include-dense-icons: $md-font-icon-include-dense) {
   .md-toolbar ~ .md-tabs {
     margin-top: 0;
   }
@@ -484,6 +485,13 @@ $md-tab-desktop-padding: 24px !default;
     font-size: $md-tab-desktop-font-size;
     line-height: $md-tab-desktop-font-size;
   }
+
+  @if $include-icons and $include-dense-icons {
+    .md-icon--tab {
+      margin-bottom: 12px;
+      margin-top: 2px;
+    }
+  }
 }
 
 /// Creates all the styles for tabs at different media sizes.
@@ -497,7 +505,7 @@ $md-tab-desktop-padding: 24px !default;
 /// @param {Boolean} include-swipeable [$md-tab-include-swipeable] - Boolean if the styles for swiping the tab
 ///   content on mobile devices should be included.
 /// @group tabs, media-queries
-@mixin react-md-tabs-media($include-icons: $md-tab-include-icons, $include-toolbars: $md-tab-include-toolbars, $include-prominent-toolbars: $md-tab-include-prominent-toolbars, $include-swipeable: $md-tab-include-swipeable) {
+@mixin react-md-tabs-media($include-icons: $md-tab-include-icons, $include-toolbars: $md-tab-include-toolbars, $include-prominent-toolbars: $md-tab-include-prominent-toolbars, $include-swipeable: $md-tab-include-swipeable, $include-dense-icons: $md-font-icon-include-dense) {
   @media #{$md-mobile-media} {
     @include react-md-tabs-mobile;
   }
@@ -517,6 +525,6 @@ $md-tab-desktop-padding: 24px !default;
   }
 
   @media #{$md-desktop-media} {
-    @include react-md-tabs-desktop;
+    @include react-md-tabs-desktop($include-icons, $include-dense-icons);
   }
 }

--- a/src/scss/components/_tabs.scss
+++ b/src/scss/components/_tabs.scss
@@ -107,6 +107,8 @@ $md-tab-desktop-padding: 24px !default;
 ///   tab overflow on desktop screens should be included.
 /// @param {Boolean} include-swipeable [$md-tab-include-swipeable] - Boolean if the styles for swiping the tab
 ///   content on mobile devices should be included.
+/// @param {Boolean} include-dense-icons [$md-font-icon-include-dense] - Boolean if the dense spec for icons should
+///   be included for tabs.
 @mixin react-md-tabs(
   $secondary-color: $md-secondary-color,
   $include-media: $md-media-included,
@@ -464,6 +466,10 @@ $md-tab-desktop-padding: 24px !default;
 }
 
 /// Includes the styles for tabs on desktop screens.
+///
+/// @param {Boolean} include-icons [$md-tab-include-icons] - Boolean if tabs with icons should be included.
+/// @param {Boolean} include-dense-icons [$md-font-icon-include-dense] - Boolean if the dense spec for icons
+///     should be used. Both this and the `$include-icons` need to be enabled to update the styles.
 /// @group tabs, media-queries
 @mixin react-md-tabs-desktop($include-icons: $md-tab-include-icons, $include-dense-icons: $md-font-icon-include-dense) {
   .md-toolbar ~ .md-tabs {
@@ -504,8 +510,16 @@ $md-tab-desktop-padding: 24px !default;
 ///   for the simple container holding a toolbar and tabs should include the prominent toolbar styles.
 /// @param {Boolean} include-swipeable [$md-tab-include-swipeable] - Boolean if the styles for swiping the tab
 ///   content on mobile devices should be included.
+/// @param {Boolean} include-dense-icons [$md-font-icon-include-dense] - Boolean if the dense spec for icons
+///   should be used for the tabs.
 /// @group tabs, media-queries
-@mixin react-md-tabs-media($include-icons: $md-tab-include-icons, $include-toolbars: $md-tab-include-toolbars, $include-prominent-toolbars: $md-tab-include-prominent-toolbars, $include-swipeable: $md-tab-include-swipeable, $include-dense-icons: $md-font-icon-include-dense) {
+@mixin react-md-tabs-media(
+  $include-icons: $md-tab-include-icons,
+  $include-toolbars: $md-tab-include-toolbars,
+  $include-prominent-toolbars: $md-tab-include-prominent-toolbars,
+  $include-swipeable: $md-tab-include-swipeable,
+  $include-dense-icons: $md-font-icon-include-dense
+) {
   @media #{$md-mobile-media} {
     @include react-md-tabs-mobile;
   }

--- a/src/scss/components/_text-fields.scss
+++ b/src/scss/components/_text-fields.scss
@@ -1211,6 +1211,8 @@ $md-text-field-desktop-floating-label-margin: 33px !default;
 ///     @include react-md-text-field-icon-desktop;
 ///   }
 ///
+/// @param {Boolean} include-password [$md-text-field-include-password] - Boolean if the password button
+///     should be included.
 /// @param {Boolean} include-dense-icons [$md-font-icon-include-dense] - Boolean if the dense font icon
 ///     styles should be included for text fields.
 /// @group text-fields, media-queries
@@ -1395,9 +1397,15 @@ $md-text-field-desktop-floating-label-margin: 33px !default;
 /// @param {Boolean} include-floating-labe [$md-text-field-include-floating-label] - Boolean if the
 ///   floating label styles for inline indicators should be included.
 /// @param {Boolean} include-block [$md-text-field-include-block] - Boolean if the block styles should
-///     be included
+///     be included.
+/// @param {Boolean} include-dense-icons [$md-font-icon-include-dense] - Boolean if the dense icons styles
+///     should be included.
 /// @group text-fields, media-queries
-@mixin react-md-text-field-inline-indicator-desktop($include-floating-label: $md-text-field-include-floating-label, $include-block: $md-text-field-include-block, $include-dense-icons: $md-font-icon-include-dense) {
+@mixin react-md-text-field-inline-indicator-desktop(
+  $include-floating-label: $md-text-field-include-floating-label,
+  $include-block: $md-text-field-include-block,
+  $include-dense-icons: $md-font-icon-include-dense
+) {
   .md-text-field-inline-indicator {
     top: if($include-dense-icons, 9px, 7px);
 

--- a/src/scss/components/_text-fields.scss
+++ b/src/scss/components/_text-fields.scss
@@ -225,6 +225,8 @@ $md-text-field-desktop-floating-label-margin: 33px !default;
 /// @param {Boolean} include-inline-indicator [$md-text-field-include-inline-indicator] - Bolean if the styling
 ///     for inline indicators should be included. If the `$include-password` param is `true`, this will automatically
 ///     be included as well.
+/// @param {Boolean} include-dense-icons [$md-font-icon-include-dense] - Boolean if the dense font icon
+///     styles should be included for text fields.
 /// @param {Map} custom-sizes [$md-text-field-custom-sizes] - A map of custom sizes to apply. If you do not
 ///     want any custom sizes, set the global or this param to null.
 /// @group text-fields, media-queries
@@ -234,6 +236,7 @@ $md-text-field-desktop-floating-label-margin: 33px !default;
   $include-icon: $md-text-field-include-icon,
   $include-password: $md-text-field-include-password,
   $include-inline-indicator: $md-text-field-include-inline-indicator,
+  $include-dense-icons: $md-font-icon-include-dense,
   $custom-sizes: $md-text-field-custom-sizes
 ) {
   @include react-md-text-field-container-desktop($include-block);
@@ -245,7 +248,7 @@ $md-text-field-desktop-floating-label-margin: 33px !default;
   }
 
   @if $include-password or $include-icon {
-    @include react-md-text-field-icon-desktop;
+    @include react-md-text-field-icon-desktop($include-password, $include-dense-icons);
   }
 
   @if $include-password or $include-inline-indicator {
@@ -280,6 +283,8 @@ $md-text-field-desktop-floating-label-margin: 33px !default;
 /// @param {Boolean} include-inline-indicator [$md-text-field-include-inline-indicator] - Bolean if the styling
 ///     for inline indicators should be included. If the `$include-password` param is `true`, this will automatically
 ///     be included as well.
+/// @param {Boolean} include-dense-icons [$md-font-icon-include-dense] - Boolean if the dense font icon
+///     styles should be included for text fields.
 /// @param {Map} custom-sizes [$md-text-field-custom-sizes] - A map of custom sizes to apply. If you do not
 ///     want any custom sizes, set the global or this param to null.
 /// @group text-fields, media-queries
@@ -289,6 +294,7 @@ $md-text-field-desktop-floating-label-margin: 33px !default;
   $include-icon: $md-text-field-include-icon,
   $include-password: $md-text-field-include-password,
   $include-inline-indicator: $md-text-field-include-inline-indicator,
+  $include-dense-icons: $md-font-icon-include-dense,
   $custom-sizes: $md-text-field-custom-sizes
 ) {
   @media #{$md-mobile-media} {
@@ -296,7 +302,7 @@ $md-text-field-desktop-floating-label-margin: 33px !default;
   }
 
   @media #{$md-desktop-media} {
-    @include react-md-text-fields-desktop($include-floating-label, $include-block, $include-icon, $include-password, $custom-sizes);
+    @include react-md-text-fields-desktop($include-floating-label, $include-block, $include-icon, $include-password, $include-dense-icons, $custom-sizes);
   }
 }
 
@@ -339,6 +345,8 @@ $md-text-field-desktop-floating-label-margin: 33px !default;
 /// @param {Boolean} include-inline-indicator [$md-text-field-include-inline-indicator] - Bolean if the styling
 ///     for inline indicators should be included. If the `$include-password` param is `true`, this will automatically
 ///     be included as well.
+/// @param {Boolean} include-dense-icons [$md-font-icon-include-dense] - Boolean if the dense font icon
+///     styles should be included for text fields.
 /// @param {Map} custom-sizes [$md-text-field-custom-sizes] - This is a map of size names and font sizes
 ///     to apply as custom sizes for the text field.
 @mixin react-md-text-fields(
@@ -353,12 +361,9 @@ $md-text-field-desktop-floating-label-margin: 33px !default;
   $include-message: $md-text-field-include-message,
   $include-password: $md-text-field-include-password,
   $include-inline-indicator: $md-text-field-include-inline-indicator,
+  $include-dense-icons: $md-font-icon-include-dense,
   $custom-sizes: $md-text-field-custom-sizes
 ) {
-  @if $include-media {
-    @include react-md-text-fields-media($include-floating-label, $include-block, $include-icon, $include-password, $custom-sizes);
-  }
-
   @include react-md-text-field-container($light-theme, $include-multiline, $include-block, $include-message);
   @include react-md-text-field($light-theme, $include-multiline);
   @include react-md-text-field-divider($primary-color, $error-color);
@@ -384,6 +389,10 @@ $md-text-field-desktop-floating-label-margin: 33px !default;
   }
 
   @include react-md-text-field-custom-sizes($md-text-field-custom-sizes, $include-floating-label);
+
+  @if $include-media {
+    @include react-md-text-fields-media($include-floating-label, $include-block, $include-icon, $include-password, $include-dense-icons, $custom-sizes);
+  }
 }
 
 
@@ -1201,12 +1210,22 @@ $md-text-field-desktop-floating-label-margin: 33px !default;
 ///   @media #{$md-desktop-media} {
 ///     @include react-md-text-field-icon-desktop;
 ///   }
+///
+/// @param {Boolean} include-dense-icons [$md-font-icon-include-dense] - Boolean if the dense font icon
+///     styles should be included for text fields.
 /// @group text-fields, media-queries
-@mixin react-md-text-field-icon-desktop {
+@mixin react-md-text-field-icon-desktop($include-password: $md-text-field-include-password, $include-dense-icons: $md-font-icon-include-dense) {
   $text-field-height: 15px;
 
   .md-text-field-icon--positioned {
-    margin-bottom: 12px - (($md-font-icon-size - $text-field-height) / 2);
+    margin-bottom: 12px - ((if($include-dense-icons, $md-font-icon-dense-size, $md-font-icon-size) - $text-field-height) / 2);
+  }
+
+  @if $include-password and $include-dense-icons {
+    .md-password-btn {
+      height: $md-font-icon-dense-size;
+      width: $md-font-icon-dense-size;
+    }
   }
 }
 
@@ -1214,14 +1233,17 @@ $md-text-field-desktop-floating-label-margin: 33px !default;
 ///
 /// @example scss - Example Usage SCSS
 ///   @include react-md-text-field-icon-media;
+///
+/// @param {Boolean} include-dense-icons [$md-font-icon-include-dense] - Boolean if the dense font icon
+///     styles should be included for text fields.
 /// @group text-fields, media-queries
-@mixin react-md-text-field-icon-media {
+@mixin react-md-text-field-icon-media($include-dense-icons: $md-font-icon-include-dense) {
   @media #{$md-mobile-media} {
     @include react-md-text-field-icon-mobile;
   }
 
   @media #{$md-desktop-media} {
-    @include react-md-text-field-icon-desktop;
+    @include react-md-text-field-icon-desktop($include-dense-icons);
   }
 }
 
@@ -1375,19 +1397,19 @@ $md-text-field-desktop-floating-label-margin: 33px !default;
 /// @param {Boolean} include-block [$md-text-field-include-block] - Boolean if the block styles should
 ///     be included
 /// @group text-fields, media-queries
-@mixin react-md-text-field-inline-indicator-desktop($include-floating-label: $md-text-field-include-floating-label, $include-block: $md-text-field-include-block) {
+@mixin react-md-text-field-inline-indicator-desktop($include-floating-label: $md-text-field-include-floating-label, $include-block: $md-text-field-include-block, $include-dense-icons: $md-font-icon-include-dense) {
   .md-text-field-inline-indicator {
-    top: 7px;
+    top: if($include-dense-icons, 9px, 7px);
 
     @if $include-floating-label {
       &--floating {
-        top: 28px;
+        top: if($include-dense-icons, 30px, 28px);
       }
     }
 
     @if $include-block {
       &--block {
-        top: 10px;
+        top: if($include-dense-icons, 12px, 10px);
       }
     }
   }

--- a/src/scss/components/_toolbars.scss
+++ b/src/scss/components/_toolbars.scss
@@ -123,6 +123,8 @@ $md-toolbar-tablet-title-keyline: 80px !default;
 ///     for select fields in toolbars should be included.
 /// @param {Boolean} include-relative-padding-class-names [$md-toolbar-include-relative-padding-class-names] - Boolean if the
 ///     relative padding class names should be included.
+/// @param {Boolean} include-dense [$md-font-icon-include-dense] - Boolean if the dense spec for icons/buttons
+///   should be included.
 /// @param {Boolean} relative-padding [$md-toolbar-relative-padding] - Boolean if the `.md-toolbar-relative` class names
 ///     should use padding instead of margin.
 @mixin react-md-toolbars(
@@ -135,10 +137,11 @@ $md-toolbar-tablet-title-keyline: 80px !default;
   $include-autocompletes: $md-toolbar-include-autocompletes,
   $include-select-fields: $md-toolbar-include-select-fields,
   $include-relative-padding-class-names: $md-toolbar-include-relative-padding-class-names,
+  $include-dense: $md-font-icon-include-dense,
   $relative-padding: $md-toolbar-relative-padding
 ) {
   @if $include-media {
-    @include react-md-toolbars-media($include-prominent, $include-btn-text, $include-autocompletes, $include-select-fields, $include-relative-padding-class-names, $relative-padding);
+    @include react-md-toolbars-media($include-prominent, $include-btn-text, $include-autocompletes, $include-select-fields, $include-relative-padding-class-names, $include-dense, $relative-padding);
   }
 
   .md-toolbar {
@@ -607,11 +610,22 @@ $md-toolbar-tablet-title-keyline: 80px !default;
 /// @group toolbars, media-queries
 /// @param {Boolean} include-select-fields [$md-toolbar-include-select-fields] - Boolean if the styles for
 ///   select fields in toolbars should be included.
-@mixin react-md-toolbars-desktop($include-select-fields: $md-toolbar-include-select-fields) {
+/// @param {Boolean} include-dense [$md-font-icon-include-dense] - Boolean if the dense spec for icons/buttons
+///   should be included.
+@mixin react-md-toolbars-desktop($include-select-fields: $md-toolbar-include-select-fields, $include-dense: $md-font-icon-include-dense) {
   @if $include-select-fields {
     .md-select-field--toolbar.md-select-field--toolbar {
       margin-bottom: 12px;
       margin-top: 12px;
+    }
+  }
+
+  @if $include-dense {
+    $margin: ($md-toolbar-tablet-height - $md-btn-icon-dense-size) / 2;
+
+    .md-btn--toolbar {
+      margin-bottom: $margin;
+      margin-top: $margin;
     }
   }
 }
@@ -632,6 +646,8 @@ $md-toolbar-tablet-title-keyline: 80px !default;
 ///     relative padding class names should be included.
 /// @param {Boolean} relative-padding [$md-toolbar-relative-padding] - Boolean if the `.md-toolbar-relative` class names
 ///     should use padding instead of margin.
+/// @param {Boolean} include-dense [$md-font-icon-include-dense] - Boolean if the dense spec for icons/buttons
+///   should be included.
 /// @group toolbars, media-queries
 @mixin react-md-toolbars-media(
   $include-prominent: $md-toolbar-include-prominent,
@@ -639,6 +655,7 @@ $md-toolbar-tablet-title-keyline: 80px !default;
   $include-autocompletes: $md-toolbar-include-autocompletes,
   $include-select-fields: $md-toolbar-include-select-fields,
   $include-relative-padding-class-names: $md-toolbar-include-relative-padding-class-names,
+  $include-dense: $md-font-icon-include-dense,
   $relative-padding: $md-toolbar-relative-padding
 ) {
   @media #{$md-mobile-media} {
@@ -657,9 +674,11 @@ $md-toolbar-tablet-title-keyline: 80px !default;
     @media #{$md-tablet-landscape-media} {
       @include react-md-toolbars-tablet-landscape($include-select-fields);
     }
+  }
 
+  @if $include-select-fields or $include-dense {
     @media #{$md-desktop-media} {
-      @include react-md-toolbars-desktop($include-select-fields);
+      @include react-md-toolbars-desktop($include-select-fields, $include-dense);
     }
   }
 }

--- a/src/scss/components/_toolbars.scss
+++ b/src/scss/components/_toolbars.scss
@@ -121,10 +121,10 @@ $md-toolbar-tablet-title-keyline: 80px !default;
 ///     for autocompletes in toolbars should be included.
 /// @param {Boolean} include-select-fields [$md-toolbar-include-select-fields] - Boolean if the styles
 ///     for select fields in toolbars should be included.
+/// @param {Boolean} include-dense-icons [$md-font-icon-include-dense] - Boolean if the dense spec for icons/buttons
+///   should be included.
 /// @param {Boolean} include-relative-padding-class-names [$md-toolbar-include-relative-padding-class-names] - Boolean if the
 ///     relative padding class names should be included.
-/// @param {Boolean} include-dense [$md-font-icon-include-dense] - Boolean if the dense spec for icons/buttons
-///   should be included.
 /// @param {Boolean} relative-padding [$md-toolbar-relative-padding] - Boolean if the `.md-toolbar-relative` class names
 ///     should use padding instead of margin.
 @mixin react-md-toolbars(
@@ -136,12 +136,12 @@ $md-toolbar-tablet-title-keyline: 80px !default;
   $include-text-fields: $md-toolbar-include-text-fields,
   $include-autocompletes: $md-toolbar-include-autocompletes,
   $include-select-fields: $md-toolbar-include-select-fields,
+  $include-dense-icons: $md-font-icon-include-dense,
   $include-relative-padding-class-names: $md-toolbar-include-relative-padding-class-names,
-  $include-dense: $md-font-icon-include-dense,
   $relative-padding: $md-toolbar-relative-padding
 ) {
   @if $include-media {
-    @include react-md-toolbars-media($include-prominent, $include-btn-text, $include-autocompletes, $include-select-fields, $include-relative-padding-class-names, $include-dense, $relative-padding);
+    @include react-md-toolbars-media($include-prominent, $include-btn-text, $include-autocompletes, $include-select-fields, $include-dense-icons, $include-relative-padding-class-names, $relative-padding);
   }
 
   .md-toolbar {
@@ -607,12 +607,18 @@ $md-toolbar-tablet-title-keyline: 80px !default;
 ///     @include react-md-toolbars-tablet-landscape;
 ///   }
 ///
-/// @group toolbars, media-queries
+/// @param {Boolean} include-btn-text [$md-toolbar-include-btn-text] - Boolean if the flat or raised
+///     button styles in toolbars should be included.
 /// @param {Boolean} include-select-fields [$md-toolbar-include-select-fields] - Boolean if the styles for
 ///   select fields in toolbars should be included.
-/// @param {Boolean} include-dense [$md-font-icon-include-dense] - Boolean if the dense spec for icons/buttons
+/// @param {Boolean} include-dense-icons [$md-font-icon-include-dense] - Boolean if the dense spec for icons/buttons
 ///   should be included.
-@mixin react-md-toolbars-desktop($include-select-fields: $md-toolbar-include-select-fields, $include-dense: $md-font-icon-include-dense) {
+/// @group toolbars, media-queries
+@mixin react-md-toolbars-desktop(
+  $include-btn-text: $md-toolbar-include-btn-text,
+  $include-select-fields: $md-toolbar-include-select-fields,
+  $include-dense-icons: $md-font-icon-include-dense
+) {
   @if $include-select-fields {
     .md-select-field--toolbar.md-select-field--toolbar {
       margin-bottom: 12px;
@@ -620,12 +626,21 @@ $md-toolbar-tablet-title-keyline: 80px !default;
     }
   }
 
-  @if $include-dense {
+  @if $include-dense-icons {
     $margin: ($md-toolbar-tablet-height - $md-btn-icon-dense-size) / 2;
 
     .md-btn--toolbar {
       margin-bottom: $margin;
       margin-top: $margin;
+    }
+  }
+
+  @if $include-btn-text {
+    $text-margin: ($md-toolbar-tablet-height - $md-btn-desktop-height) / 2;
+
+    .md-toolbar .md-btn--text {
+      margin-bottom: $text-margin;
+      margin-top: $text-margin;
     }
   }
 }
@@ -642,20 +657,20 @@ $md-toolbar-tablet-title-keyline: 80px !default;
 ///     for autocompletes in toolbars should be included.
 /// @param {Boolean} include-select-fields [$md-toolbar-include-select-fields] - Boolean if the styles
 ///     for select fields in toolbars should be included.
+/// @param {Boolean} include-dense-icons [$md-font-icon-include-dense] - Boolean if the dense spec for icons/buttons
+///   should be included.
 /// @param {Boolean} include-relative-padding-class-names [$md-toolbar-include-relative-padding-class-names] - Boolean if the
 ///     relative padding class names should be included.
 /// @param {Boolean} relative-padding [$md-toolbar-relative-padding] - Boolean if the `.md-toolbar-relative` class names
 ///     should use padding instead of margin.
-/// @param {Boolean} include-dense [$md-font-icon-include-dense] - Boolean if the dense spec for icons/buttons
-///   should be included.
 /// @group toolbars, media-queries
 @mixin react-md-toolbars-media(
   $include-prominent: $md-toolbar-include-prominent,
   $include-btn-text: $md-toolbar-include-btn-text,
   $include-autocompletes: $md-toolbar-include-autocompletes,
   $include-select-fields: $md-toolbar-include-select-fields,
+  $include-dense-icons: $md-font-icon-include-dense,
   $include-relative-padding-class-names: $md-toolbar-include-relative-padding-class-names,
-  $include-dense: $md-font-icon-include-dense,
   $relative-padding: $md-toolbar-relative-padding
 ) {
   @media #{$md-mobile-media} {
@@ -676,9 +691,9 @@ $md-toolbar-tablet-title-keyline: 80px !default;
     }
   }
 
-  @if $include-select-fields or $include-dense {
+  @if $include-select-fields or $include-dense-icons {
     @media #{$md-desktop-media} {
-      @include react-md-toolbars-desktop($include-select-fields, $include-dense);
+      @include react-md-toolbars-desktop($include-btn-text, $include-select-fields, $include-dense-icons);
     }
   }
 }


### PR DESCRIPTION
Added a dense spec for icons. This can be disabled by setting the
`$md-font-icon-include-dense` variable to `false`.

Closes #217