### PR TITLE
Fixed Slider to correctly render balloon on tick

### DIFF
--- a/src/js/Sliders/Slider.js
+++ b/src/js/Sliders/Slider.js
@@ -419,6 +419,8 @@ export default class Slider extends PureComponent {
       distance = 0;
     } else if (distance === props.max) {
       distance = 100;
+    } else if (props.min > 1 && props.defaultValue !== 0) {
+      distance = Math.max(0, Math.min(100, ((props.defaultValue - props.min) / (props.max - props.min)) * 100));
     } else {
       distance = value / props.max * 100;
     }

--- a/src/js/Sliders/__tests__/Slider.js
+++ b/src/js/Sliders/__tests__/Slider.js
@@ -146,4 +146,36 @@ describe('Slider', () => {
     props = findRenderedComponentWithType(slider, Track).props;
     expect(props.disabled).toBe(true);
   });
+
+  it('renders the balloon on correct tick when min value is greater than 0 & defaultValue is not 0', () => {
+    const renderSliderWithProps = (defaultValue, min, max) => {
+      const props = { defaultValue, min, max };
+      return renderIntoDocument(<Slider {...props} />);
+    };
+
+    let slider = renderSliderWithProps(5, 3, 12);
+    expect(slider.state.distance).toEqual(22.22222222222222);
+
+    slider = renderSliderWithProps(55, 40, 77);
+    expect(slider.state.distance).toEqual(40.54054054054054);
+
+    slider = renderSliderWithProps(1076, 200, 20000);
+    expect(slider.state.distance).toEqual(4.424242424242424);
+  });
+
+  it('renders the slider correctly without a defaultValue', () => {
+    const renderSliderWithProps = (defaultValue, max) => {
+      const props = { defaultValue, max };
+      return renderIntoDocument(<Slider {...props} />);
+    };
+
+    let slider = renderSliderWithProps(5, 12);
+    expect(slider.state.distance).toEqual(41.66666666666667);
+
+    slider = renderSliderWithProps(55, 77);
+    expect(slider.state.distance).toEqual(71.42857142857143);
+
+    slider = renderSliderWithProps(1076, 20000);
+    expect(slider.state.distance).toEqual(5.38);
+  });
 });


### PR DESCRIPTION
Fix issue when a min/max & defaultValue were given as props to a Slider, the bubble would not render on the correct tick. 

Added tests for the scenario

Values for images: 

`props: {
  defalutValue: 5,
  min: 3,
  max: 12
}`

Before fix: 
![image](https://cloud.githubusercontent.com/assets/10872765/23627269/ee7428d4-0264-11e7-9a48-09a4b3e8c5f5.png)

Closest tick is 7: 
![image](https://cloud.githubusercontent.com/assets/10872765/23627308/1dcd4dc2-0265-11e7-86c2-e2c585daff25.png)

Tick should be at 5 & does correctly after fix
