### PR TITLE
Add NavigationDrawer.drawerHeaderChildren prop to typing

### DIFF
--- a/src/js/NavigationDrawers/index.d.ts
+++ b/src/js/NavigationDrawers/index.d.ts
@@ -14,6 +14,7 @@ interface NavigationDrawerProps extends Props {
   children?: React.ReactNode;
   includeDrawerHeader?: boolean;
   drawerHeader?: React.ReactNode;
+  drawerHeaderChildren?: React.ReactNode;
   drawerTitle?: React.ReactNode;
   drawerChildren?: React.ReactNode;
   position?: DrawerPositions;


### PR DESCRIPTION
This property is missing from typing but it's still in the source. Not sure if you have plans to remove it?