### PR TITLE
Updated Drawer/NavigationDrawer type resolving

### DIFF
--- a/src/js/Drawers/Drawer.js
+++ b/src/js/Drawers/Drawer.js
@@ -261,6 +261,15 @@ export default class Drawer extends PureComponent {
      * Boolean if the navigation drawer should automatically close when a nav item has been clicked.
      */
     closeOnNavItemClick: PropTypes.bool,
+
+    /**
+     * Boolean if the `type` prop should be constant across all media sizes. This is only valid if the `type` is
+     * one of the temporary types.
+     *
+     * This will basically mean that when attempting to do a media adjustment, it will use the `type` prop instead of
+     * `mobileType`, `tabletType`, and `desktopType` to determine the next drawer type.
+     */
+    constantType: PropTypes.bool.isRequired,
   };
 
   static defaultProps = {
@@ -276,6 +285,7 @@ export default class Drawer extends PureComponent {
     autoclose: true,
     clickableDesktopOverlay: true,
     closeOnNavItemClick: true,
+    constantType: true,
   };
 
   /**
@@ -289,9 +299,18 @@ export default class Drawer extends PureComponent {
    * @return {Object} an object containing the media matches and the current type to use for the drawer.
    */
   static getCurrentMedia(props = Drawer.defaultProps) {
-    const { mobileMinWidth, tabletMinWidth, desktopMinWidth, mobileType, tabletType, desktopType } = props;
+    const {
+      mobileMinWidth,
+      tabletMinWidth,
+      desktopMinWidth,
+      mobileType,
+      tabletType,
+      desktopType,
+      constantType,
+    } = props;
     if (typeof window === 'undefined') {
-      return { mobile: true, tablet: false, desktop: false, type: mobileType };
+      const type = constantType && props.type ? props.type : mobileType;
+      return { mobile: true, tablet: false, desktop: false, type };
     }
 
     const mobile = Drawer.matchesMedia(mobileMinWidth, tabletMinWidth - 1);
@@ -299,7 +318,9 @@ export default class Drawer extends PureComponent {
     const desktop = Drawer.matchesMedia(desktopMinWidth);
 
     let type;
-    if (desktop) {
+    if (constantType && props.type && isTemporary(props.type)) {
+      type = props.type;
+    } else if (desktop) {
       type = desktopType;
     } else if (tablet) {
       type = tabletType;
@@ -550,7 +571,7 @@ export default class Drawer extends PureComponent {
       lastChild,
       ...props
     } = this.props;
-    delete props.drawerType;
+    delete props.constantType;
     delete props.renderNode;
     delete props.visible;
     delete props.defaultVisible;

--- a/src/js/Drawers/__tests__/Drawer.js
+++ b/src/js/Drawers/__tests__/Drawer.js
@@ -183,29 +183,89 @@ describe('Drawer', () => {
 
   describe('getCurrentMedia', () => {
     const { mobileMinWidth, tabletMinWidth, desktopMinWidth } = Drawer.defaultProps;
+    const matchMobile = jest.fn(query => ({
+      matches: !!query.match(`min-width: ${mobileMinWidth}`),
+    }));
+    const matchTablet = jest.fn(query => ({
+      matches: !!query.match(`min-width: ${tabletMinWidth}`),
+    }));
+    const matchDesktop = jest.fn(query => ({
+      matches: !!query.match(`min-width: ${desktopMinWidth}`),
+    }));
     const MATCH_MEDIA = window.matchMedia;
     it('should return the mobile drawer type when the media matches mobile', () => {
-      window.matchMedia = jest.fn(query => ({
-        matches: !!query.match(`min-width: ${mobileMinWidth}`),
-      }));
+      window.matchMedia = matchMobile;
       const expected = { mobile: true, tablet: false, desktop: false, type: Drawer.defaultProps.mobileType };
       expect(Drawer.getCurrentMedia()).toEqual(expected);
     });
 
     it('should return the tablet drawer type when the media matches tablet', () => {
-      window.matchMedia = jest.fn(query => ({
-        matches: !!query.match(`min-width: ${tabletMinWidth}`),
-      }));
+      window.matchMedia = matchTablet;
       const expected = { mobile: false, tablet: true, desktop: false, type: Drawer.defaultProps.tabletType };
       expect(Drawer.getCurrentMedia()).toEqual(expected);
     });
 
     it('should return the desktop drawer type when the media matches desktop', () => {
-      window.matchMedia = jest.fn(query => ({
-        matches: !!query.match(`min-width: ${desktopMinWidth}`),
-      }));
+      window.matchMedia = matchDesktop;
       const expected = { mobile: false, tablet: false, desktop: true, type: Drawer.defaultProps.desktopType };
       expect(Drawer.getCurrentMedia()).toEqual(expected);
+    });
+
+    it('should return the current type prop if constantType is enabled for any media', () => {
+      const props = { ...Drawer.defaultProps, type: Drawer.DrawerTypes.TEMPORARY, constantType: true };
+      window.matchMedia = matchMobile;
+      const expected = {
+        mobile: true,
+        tablet: false,
+        desktop: false,
+        type: props.type,
+      };
+
+      expect(Drawer.getCurrentMedia(props)).toEqual(expected);
+
+      window.matchMedia = matchTablet;
+      expected.mobile = false;
+      expected.tablet = true;
+      expect(Drawer.getCurrentMedia(props)).toEqual(expected);
+
+      window.matchMedia = matchDesktop;
+      expected.tablet = false;
+      expected.desktop = true;
+      expect(Drawer.getCurrentMedia(props)).toEqual(expected);
+    });
+
+    it('should still do the media type matches if constantType is not enabled', () => {
+      const { TEMPORARY, PERSISTENT, FULL_HEIGHT } = Drawer.DrawerTypes;
+      const props = {
+        ...Drawer.defaultProps,
+        type: TEMPORARY,
+        constantType: false,
+        mobileType: TEMPORARY,
+        tabletType: PERSISTENT,
+        desktopType: FULL_HEIGHT,
+      };
+
+      window.matchMedia = matchMobile;
+      const expected = {
+        mobile: true,
+        tablet: false,
+        desktop: false,
+        type: TEMPORARY,
+      };
+
+      expect(Drawer.getCurrentMedia(props)).toEqual(expected);
+
+      window.matchMedia = matchTablet;
+      expected.mobile = false;
+      expected.tablet = true;
+      expected.type = PERSISTENT;
+      expect(Drawer.getCurrentMedia(props)).toEqual(expected);
+
+      window.matchMedia = matchDesktop;
+      expected.tablet = false;
+      expected.desktop = true;
+      expected.type = FULL_HEIGHT;
+      expect(Drawer.getCurrentMedia(props)).toEqual(expected);
     });
 
     afterAll(() => {

--- a/src/js/NavigationDrawers/NavigationDrawer.js
+++ b/src/js/NavigationDrawers/NavigationDrawer.js
@@ -570,6 +570,12 @@ export default class NavigationDrawer extends PureComponent {
      */
     lastChild: PropTypes.bool,
 
+    /**
+     * Boolean if the `drawerType` should remain constant across all media. This is really only valid
+     * if the `drawerType` is one of the temporary types.
+     */
+    constantDrawerType: PropTypes.bool,
+
     menuIconChildren: deprecated(PropTypes.node, 'Use `temporaryIconChildren` instead'),
     menuIconClassName: deprecated(PropTypes.string, 'Use `temporaryIconClassName` instead'),
     closeIconChildren: deprecated(PropTypes.node, 'Use `persistentIconChildren` instead'),
@@ -603,6 +609,10 @@ export default class NavigationDrawer extends PureComponent {
   static defaultProps = {
     autoclose: Drawer.defaultProps.autoclose,
     contentId: 'main-content',
+    // Defaults to false since it keeps the state of the drawerType in sync and makes the Drawer
+    // controlled. On initial mount without any defaultMedia updates, it would always be considered
+    // temporary
+    constantDrawerType: false,
     jumpLabel: 'Jump to content',
     extractMini: true,
     position: Drawer.defaultProps.position,
@@ -638,10 +648,11 @@ export default class NavigationDrawer extends PureComponent {
       mobileDrawerType: mobileType,
       tabletDrawerType: tabletType,
       desktopDrawerType: desktopType,
+      constantDrawerType: constantType,
       ...others
     } = props;
 
-    return Drawer.getCurrentMedia({ mobileType, tabletType, desktopType, ...others });
+    return Drawer.getCurrentMedia({ mobileType, tabletType, desktopType, constantType, ...others });
   }
 
   constructor(props) {
@@ -796,6 +807,7 @@ export default class NavigationDrawer extends PureComponent {
       includeDrawerHeader,
       contentId,
       contentProps,
+      constantDrawerType,
       ...props
     } = this.props;
     delete props.drawerType;
@@ -913,6 +925,7 @@ export default class NavigationDrawer extends PureComponent {
         {miniDrawer}
         <Drawer
           {...props}
+          constantType={constantDrawerType}
           transitionDuration={drawerTransitionDuration}
           header={drawerHeader}
           style={drawerStyle}

--- a/src/js/NavigationDrawers/__tests__/NavigationDrawer.js
+++ b/src/js/NavigationDrawers/__tests__/NavigationDrawer.js
@@ -149,5 +149,38 @@ describe('NavigationDrawer', () => {
       expect(props.onMediaTypeChange).toBeCalledWith(NavigationDrawer.defaultProps.mobileDrawerType, { mobile: true, tablet: false, desktop: false });
       expect(props.onVisibilityToggle).toBeCalledWith(true);
     });
+
+    it('should not attempt to update the drawer type be the media drawer type if constantDrawerType is enabled', () => {
+      const { TEMPORARY } = NavigationDrawer.DrawerTypes;
+      const onMediaTypeChange = jest.fn();
+      renderIntoDocument(<NavigationDrawer constantDrawerType drawerType={TEMPORARY} onMediaTypeChange={onMediaTypeChange} />);
+      expect(onMediaTypeChange.mock.calls.length).toBe(0);
+    });
+
+    it('should attempt to update the drawer type to be the media drawer type if the constantDrawerType is not enabled', () => {
+      window.matchMedia = matchesMobile;
+      const { TEMPORARY, PERSISTENT, FULL_HEIGHT } = NavigationDrawer.DrawerTypes;
+      const onMediaTypeChange = jest.fn();
+      const props = {
+        drawerType: TEMPORARY,
+        mobileDrawerType: TEMPORARY,
+        tabletDrawerType: PERSISTENT,
+        desktopDrawerType: FULL_HEIGHT,
+        onMediaTypeChange,
+        constantDrawerType: false,
+      };
+      renderIntoDocument(<NavigationDrawer {...props} />);
+      expect(onMediaTypeChange.mock.calls.length).toBe(0);
+
+      window.matchMedia = matchesTablet;
+      renderIntoDocument(<NavigationDrawer {...props} />);
+      expect(onMediaTypeChange.mock.calls.length).toBe(1);
+      expect(onMediaTypeChange).toBeCalledWith(PERSISTENT, { mobile: false, tablet: true, desktop: false });
+
+      window.matchMedia = matchesDesktop;
+      renderIntoDocument(<NavigationDrawer {...props} />);
+      expect(onMediaTypeChange.mock.calls.length).toBe(2);
+      expect(onMediaTypeChange).toBeCalledWith(FULL_HEIGHT, { mobile: false, tablet: false, desktop: true });
+    });
   });
 });


### PR DESCRIPTION
Updated the logic for resolving the current drawer's media type to allow
the props.type to always be used instead of attempting to find the
current media type match.

This is really only useful when the preferred usage of the drawer is
to use one of the temporary types across on media devices.

Closes #291