### PR TITLE
Feature/fixed tables

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -26,6 +26,7 @@
     "express": "^4.15.2",
     "fuse.js": "^2.6.2",
     "helmet": "^3.5.0",
+    "lodash": "^4.17.4",
     "morgan": "^1.8.1",
     "react-docgen": "^2.13.0",
     "sassdoc": "^2.2.0",

--- a/api/src/utils/transformSassdocFunction.js
+++ b/api/src/utils/transformSassdocFunction.js
@@ -1,5 +1,4 @@
-import transformSassdocVariable from './transformSassdocVariable';
-import { buildSassDocLink } from './buildSassDocList';
+import transformSassdocVariable, { refList } from './transformSassdocVariable';
 
 function transformParams({ name, default: value }) {
   return `$${name}${value ? `: ${value}` : ''}`;
@@ -12,7 +11,7 @@ function transformRequires({ name, type, item: { group } }) {
 export default function transformSassdocFunction(sassdoc) {
   const {
     parameter: parameters,
-    require: requires,
+    require,
     return: returns,
     context: { name, type, code },
   } = sassdoc;
@@ -21,10 +20,15 @@ export default function transformSassdocFunction(sassdoc) {
     ? `(${parameters.map(transformParams).join(', ')})`
     : '';
 
+  let requires = [];
+  if (require) {
+    requires = refList(requires.map(transformRequires));
+  }
+
   return Object.assign(transformSassdocVariable(sassdoc), {
     code: `@${type} ${name}${params} {${code}}`,
     parameters: parameters || [],
-    requires: requires ? requires.map(transformRequires).map(buildSassDocLink) : [],
+    requires,
     returns,
   });
 }

--- a/api/src/utils/transformSassdocVariable.js
+++ b/api/src/utils/transformSassdocVariable.js
@@ -1,6 +1,11 @@
+import { uniqBy } from 'lodash/array';
 import { buildSassDocLink } from './buildSassDocList';
 
 const GITHUB_URL = require('../../../package.json').bugs.url.replace('/issues', '');
+
+export function refList(list) {
+  return list ? uniqBy(list.map(buildSassDocLink), ({ name }) => name) : [];
+}
 
 export default function transformSassdocVariable(sassdoc) {
   const {
@@ -11,7 +16,6 @@ export default function transformSassdocVariable(sassdoc) {
       scope,
     },
     description,
-    usedBy,
     file: { path },
     type: variableType,
     example: examples,
@@ -26,10 +30,9 @@ export default function transformSassdocVariable(sassdoc) {
     code = `%${name} {${code}}`;
   }
 
-  let { see } = sassdoc;
-  if (see && see.length) {
-    see = see.map(buildSassDocLink);
-  }
+  let { see, usedBy } = sassdoc;
+  see = refList(see);
+  usedBy = refList(usedBy);
 
   return {
     name,
@@ -40,7 +43,7 @@ export default function transformSassdocVariable(sassdoc) {
     links,
     examples,
     see,
-    usedBy: usedBy ? usedBy.map(buildSassDocLink) : [],
+    usedBy,
     path: `${GITHUB_URL}/blob/master/src/scss/${path}`,
   };
 }

--- a/docs/src/shared/components/ReactMD/data-tables/ConfigurableTableExample/Body.jsx
+++ b/docs/src/shared/components/ReactMD/data-tables/ConfigurableTableExample/Body.jsx
@@ -7,7 +7,7 @@ import EditDialogColumn from 'react-md/lib/DataTables/EditDialogColumn';
 const Body = ({ inline, large, okOnOutsideClick, movies }) => {
   const rows = movies.map(({ title, year }) => (
     <TableRow key={title}>
-      <TableColumn>{title}</TableColumn>
+      <TableColumn grow>{title}</TableColumn>
       <TableColumn numeric>{year}</TableColumn>
       <EditDialogColumn
         label={inline ? null : 'Add some comment'}

--- a/docs/src/shared/components/ReactMD/data-tables/ConfigurableTableExample/Configuration.jsx
+++ b/docs/src/shared/components/ReactMD/data-tables/ConfigurableTableExample/Configuration.jsx
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react';
 import CardText from 'react-md/lib/Cards/CardText';
 import SelectionControl from 'react-md/lib/SelectionControls/SelectionControl';
 import SelectionControlGroup from 'react-md/lib/SelectionControls/SelectionControlGroup';
+import TextField from 'react-md/lib/TextFields';
 
 const controls = [{
   label: 'Sort by movie title',
@@ -20,6 +21,14 @@ const Configuration = ({
   onInlineChange,
   saveChecked,
   onSaveChange,
+  fixedHeader,
+  onFixedHeaderChange,
+  fixedFooter,
+  onFixedFooterChange,
+  fixedHeight,
+  onHeightChange,
+  fixedWidth,
+  onWidthChange,
 }) => (
   <CardText>
     <SelectionControlGroup
@@ -55,6 +64,40 @@ const Configuration = ({
       checked={saveChecked}
       onChange={onSaveChange}
     />
+    <SelectionControl
+      type="switch"
+      id="configuration-fixed-header"
+      label="Fixed Header"
+      name="fixed-header"
+      checked={fixedHeader}
+      onChange={onFixedHeaderChange}
+    />
+    <SelectionControl
+      type="switch"
+      id="configuration-fixed-footer"
+      label="Fixed Footer"
+      name="fixed-footer"
+      checked={fixedFooter}
+      onChange={onFixedFooterChange}
+    />
+    <TextField
+      id="configuration-fixed-height"
+      label="Fixed Height"
+      type="number"
+      value={fixedHeight}
+      onChange={onHeightChange}
+      className="md-cell"
+      disabled={!fixedHeader}
+    />
+    <TextField
+      id="configuration-fixed-width"
+      label="Fixed Width"
+      type="number"
+      value={fixedWidth}
+      onChange={onWidthChange}
+      className="md-cell"
+      disabled={!fixedHeader && !fixedFooter}
+    />
   </CardText>
 );
 
@@ -67,6 +110,14 @@ Configuration.propTypes = {
   onInlineChange: PropTypes.func.isRequired,
   saveChecked: PropTypes.bool.isRequired,
   onSaveChange: PropTypes.func.isRequired,
+  fixedHeader: PropTypes.bool.isRequired,
+  onFixedHeaderChange: PropTypes.func.isRequired,
+  fixedFooter: PropTypes.bool.isRequired,
+  onFixedFooterChange: PropTypes.func.isRequired,
+  fixedHeight: PropTypes.number.isRequired,
+  onHeightChange: PropTypes.func.isRequired,
+  fixedWidth: PropTypes.number.isRequired,
+  onWidthChange: PropTypes.func.isRequired,
 };
 
 export default Configuration;

--- a/docs/src/shared/components/ReactMD/data-tables/ConfigurableTableExample/Footer.jsx
+++ b/docs/src/shared/components/ReactMD/data-tables/ConfigurableTableExample/Footer.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import TableFooter from 'react-md/lib/DataTables/TableFooter';
+import TableRow from 'react-md/lib/DataTables/TableRow';
+import TableColumn from 'react-md/lib/DataTables/TableColumn';
+
+const Footer = () => (
+  <TableFooter>
+    <TableRow selectable={false}>
+      <TableColumn colSpan="100%">
+        <h3 style={{ margin: 0 }}>This is a footer. Quite amazing. Yes.</h3>
+      </TableColumn>
+    </TableRow>
+  </TableFooter>
+);
+
+export default Footer;

--- a/docs/src/shared/components/ReactMD/data-tables/ConfigurableTableExample/Header.jsx
+++ b/docs/src/shared/components/ReactMD/data-tables/ConfigurableTableExample/Header.jsx
@@ -2,13 +2,19 @@ import React, { PropTypes } from 'react';
 import TableHeader from 'react-md/lib/DataTables/TableHeader';
 import TableRow from 'react-md/lib/DataTables/TableRow';
 import TableColumn from 'react-md/lib/DataTables/TableColumn';
-import FontIcon from 'react-md/lib/FontIcons';
-import IconSeparator from 'react-md/lib/Helpers/IconSeparator';
+import EditDialogColumn from 'react-md/lib/DataTables/EditDialogColumn';
 
+import FontIcon from 'react-md/lib/FontIcons';
+// import IconSeparator from 'react-md/lib/Helpers/IconSeparator';
+
+// Since the fixed stuff comes from context and most components are Pure, can cheat a bit
+// for the demo to do timestamps as keys to get the update. The fixed part should really
+// be more static instead of dynamic
 const Header = ({ titleSorted, yearSorted, sort }) => (
   <TableHeader>
     <TableRow>
       <TableColumn
+        key={Date.now()}
         sorted={titleSorted}
         onClick={typeof titleSorted === 'boolean' ? sort : null}
         tooltipLabel="The movie's title"
@@ -16,6 +22,7 @@ const Header = ({ titleSorted, yearSorted, sort }) => (
         Title
       </TableColumn>
       <TableColumn
+        key={Date.now() + 1}
         numeric
         sorted={yearSorted}
         onClick={typeof yearSorted === 'boolean' ? sort : null}
@@ -23,11 +30,14 @@ const Header = ({ titleSorted, yearSorted, sort }) => (
       >
         Year
       </TableColumn>
-      <TableColumn className="prevent-grow">
-        <IconSeparator label="Comments" iconBefore>
-          <FontIcon>chat</FontIcon>
-        </IconSeparator>
-      </TableColumn>
+      <EditDialogColumn
+        key={Date.now() + 2}
+        inline
+        noIcon
+        leftIcon={<FontIcon>chat</FontIcon>}
+        defaultValue="Comments"
+        tooltipLabel="Add a comment!"
+      />
     </TableRow>
   </TableHeader>
 );

--- a/docs/src/shared/components/ReactMD/data-tables/ConfigurableTableExample/index.jsx
+++ b/docs/src/shared/components/ReactMD/data-tables/ConfigurableTableExample/index.jsx
@@ -7,6 +7,7 @@ import sort from 'utils/ListUtils/sort';
 import Configuration from './Configuration';
 import Header from './Header';
 import Body from './Body';
+import Footer from './Footer';
 
 export default class ConfigurableTableExample extends PureComponent {
   constructor(props) {
@@ -20,6 +21,10 @@ export default class ConfigurableTableExample extends PureComponent {
       titleSorted: true,
       yearSorted: null,
       okOnOutsideClick: true,
+      fixedHeader: true,
+      fixedFooter: true,
+      fixedHeight: 0,
+      fixedWidth: 0,
     };
   }
 
@@ -55,6 +60,22 @@ export default class ConfigurableTableExample extends PureComponent {
     this.setState({ okOnOutsideClick });
   };
 
+  handleFixedHeaderChange = (fixedHeader) => {
+    this.setState({ fixedHeader });
+  };
+
+  handleFixedFooterChange = (fixedFooter) => {
+    this.setState({ fixedFooter });
+  };
+
+  handleHeightChange = (value) => {
+    this.setState({ fixedHeight: parseFloat(value || 0) });
+  };
+
+  handleWidthChange = (value) => {
+    this.setState({ fixedWidth: parseFloat(value || 0) });
+  };
+
   render() {
     const {
       large,
@@ -64,7 +85,12 @@ export default class ConfigurableTableExample extends PureComponent {
       titleSorted,
       sortedType,
       sortedMovies,
+      fixedHeader,
+      fixedFooter,
+      fixedWidth,
+      fixedHeight,
     } = this.state;
+
     return (
       <div>
         <Configuration
@@ -76,10 +102,26 @@ export default class ConfigurableTableExample extends PureComponent {
           onSortChange={this.changeSortType}
           saveChecked={okOnOutsideClick}
           onSaveChange={this.handleSaveChange}
+          fixedHeader={fixedHeader}
+          onFixedHeaderChange={this.handleFixedHeaderChange}
+          fixedFooter={fixedFooter}
+          onFixedFooterChange={this.handleFixedFooterChange}
+          fixedHeight={fixedHeight}
+          onHeightChange={this.handleHeightChange}
+          fixedWidth={fixedWidth}
+          onWidthChange={this.handleWidthChange}
         />
-        <DataTable baseId="movies" className="movies-table" fixedHeader>
+        <DataTable
+          baseId="movies"
+          className="movies-table"
+          fixedHeader={fixedHeader}
+          fixedFooter={fixedFooter}
+          fixedHeight={fixedHeight !== 0 ? fixedHeight : null}
+          fixedWidth={fixedWidth !== 0 ? fixedWidth : null}
+        >
           <Header yearSorted={yearSorted} titleSorted={titleSorted} sort={this.sort} />
           <Body movies={sortedMovies} inline={inline} large={large} okOnOutsideClick={okOnOutsideClick} />
+          <Footer />
         </DataTable>
       </div>
     );

--- a/docs/src/shared/components/ReactMD/data-tables/ConfigurableTableExample/index.jsx
+++ b/docs/src/shared/components/ReactMD/data-tables/ConfigurableTableExample/index.jsx
@@ -77,7 +77,7 @@ export default class ConfigurableTableExample extends PureComponent {
           saveChecked={okOnOutsideClick}
           onSaveChange={this.handleSaveChange}
         />
-        <DataTable baseId="movies">
+        <DataTable baseId="movies" className="movies-table" fixedHeader>
           <Header yearSorted={yearSorted} titleSorted={titleSorted} sort={this.sort} />
           <Body movies={sortedMovies} inline={inline} large={large} okOnOutsideClick={okOnOutsideClick} />
         </DataTable>

--- a/docs/src/shared/components/ReactMD/data-tables/DynamicContentTable/Header.jsx
+++ b/docs/src/shared/components/ReactMD/data-tables/DynamicContentTable/Header.jsx
@@ -8,13 +8,13 @@ const Header = () => (
     <TableRow>
       <TableColumn grow>Dessert (100g serving)</TableColumn>
       <TableColumn selectColumnHeader>Type</TableColumn>
-      <TableColumn numeric adjusted={false}>Calories</TableColumn>
-      <TableColumn numeric adjusted={false}>Fat (g)</TableColumn>
-      <TableColumn numeric adjusted={false}>Carbs (g)</TableColumn>
-      <TableColumn numeric adjusted={false}>Protein (g)</TableColumn>
-      <TableColumn numeric adjusted={false}>Sodium (mg)</TableColumn>
-      <TableColumn numeric adjusted={false}>Calcium (%)</TableColumn>
-      <TableColumn numeric adjusted={false}>Iron (%)</TableColumn>
+      <TableColumn numeric adjusted={false} fixedClassName="nutrition-table__fixed-number">Calories</TableColumn>
+      <TableColumn numeric adjusted={false} fixedClassName="nutrition-table__fixed-number">Fat (g)</TableColumn>
+      <TableColumn numeric adjusted={false} fixedClassName="nutrition-table__fixed-number">Carbs (g)</TableColumn>
+      <TableColumn numeric adjusted={false} fixedClassName="nutrition-table__fixed-number">Protein (g)</TableColumn>
+      <TableColumn numeric adjusted={false} fixedClassName="nutrition-table__fixed-number">Sodium (mg)</TableColumn>
+      <TableColumn numeric adjusted={false} fixedClassName="nutrition-table__fixed-number">Calcium (%)</TableColumn>
+      <TableColumn numeric adjusted={false} fixedClassName="nutrition-table__fixed-number">Iron (%)</TableColumn>
     </TableRow>
   </TableHeader>
 );

--- a/docs/src/shared/components/ReactMD/data-tables/DynamicContentTable/_styles.scss
+++ b/docs/src/shared/components/ReactMD/data-tables/DynamicContentTable/_styles.scss
@@ -29,10 +29,6 @@
   right: -8px;
 }
 
-.nutrition-table {
-  @include react-md-make-fixed-table(300px);
-}
-
 .movies-table {
-  @include react-md-make-fixed-table(300px);
+  @include react-md-make-fixed-table(true, $md-data-table-header-height, $md-data-table-column-height, $md-toolbar-prominent-height);
 }

--- a/docs/src/shared/components/ReactMD/data-tables/DynamicContentTable/_styles.scss
+++ b/docs/src/shared/components/ReactMD/data-tables/DynamicContentTable/_styles.scss
@@ -9,6 +9,11 @@
   }
 }
 
+.nutrition-table__fixed-number {
+  min-width: 120px;
+  padding-right: 24px;
+}
+
 .nutrition-table__number-column {
   min-width: 120px;
 
@@ -22,4 +27,12 @@
   content: '%';
   position: absolute;
   right: -8px;
+}
+
+.nutrition-table {
+  @include react-md-make-fixed-table(300px);
+}
+
+.movies-table {
+  @include react-md-make-fixed-table(300px);
 }

--- a/docs/src/shared/components/ReactMD/data-tables/DynamicContentTable/index.jsx
+++ b/docs/src/shared/components/ReactMD/data-tables/DynamicContentTable/index.jsx
@@ -111,7 +111,7 @@ export default class DynamicContentTable extends PureComponent {
           removeSelected={this.removeSelected}
           openAddRowDialog={this.openAddRowDialog}
         />
-        <DataTable baseId="nutrition" onRowToggle={this.handleRowToggle} className="nutrition-table">
+        <DataTable baseId="nutrition" onRowToggle={this.handleRowToggle} className="nutrition-table" fixedHeader>
           <Header />
           <Body facts={facts} mobile={mobile} />
         </DataTable>

--- a/docs/src/shared/components/ReactMD/data-tables/DynamicContentTable/index.jsx
+++ b/docs/src/shared/components/ReactMD/data-tables/DynamicContentTable/index.jsx
@@ -111,7 +111,7 @@ export default class DynamicContentTable extends PureComponent {
           removeSelected={this.removeSelected}
           openAddRowDialog={this.openAddRowDialog}
         />
-        <DataTable baseId="nutrition" onRowToggle={this.handleRowToggle} className="nutrition-table" fixedHeader>
+        <DataTable baseId="nutrition" onRowToggle={this.handleRowToggle} className="nutrition-table">
           <Header />
           <Body facts={facts} mobile={mobile} />
         </DataTable>

--- a/docs/src/shared/components/ReactMD/data-tables/PaginationExample/index.jsx
+++ b/docs/src/shared/components/ReactMD/data-tables/PaginationExample/index.jsx
@@ -84,7 +84,7 @@ export default class PaginationExample extends PureComponent {
 
     return (
       <Loader fetching={fetching} loaded={!!inspections.length} onLoad={this._load}>
-        <DataTable className="pagination-table" baseId="pagination">
+        <DataTable className="pagination-table" baseId="pagination" fixedHeader fixedFooter fixedHeight={400} footerHeight={56}>
           <TableHeader>
             <TableRow>
               {headers}

--- a/docs/src/shared/components/ReactMD/data-tables/index.js
+++ b/docs/src/shared/components/ReactMD/data-tables/index.js
@@ -46,6 +46,53 @@ manually on your end.
 The \`EditDialogColumn\` can be displayed in a dialog, a large dialog, or inline. The defalt behavior for the dialog
 versions is to "save" the cell when the user presses enter. If the user hits escape, their changes will be undone and
 the value will be reset before the dialog was opened.
+
+This example will also allow you to play with fixed headers/footers for a table.  To be able to get fixed tables,
+the table must be \`responsive\` to get horizontal scrolling. Once a table has become "fixed" with header/footer,
+the markup changes remarkably.
+
+\`\`\`html
+<!-- before -->
+<div class="md-data-table--responsive">
+  <table class="md-data-table">
+    <thead class="md-table-header">
+      <tr class="md-table-row">
+        <th class="md-table-column">
+          Hi!
+        </th>
+      </tr>
+    </thead>
+    <!-- table stuffs -->
+  </table>
+</div>
+
+<!-- after -->
+<div class="md-data-table--responsive">
+  <div class="md-data-table__fixed-wrapper">
+    <div class="md-data-table--scroll-wrapper">
+      <table class="md-data-table">
+        <thead class="md-table-header">
+          <tr class="md-table-row">
+            <th class="md-table-column">
+              <div class="md-table-column__fixed">
+                <div class"md-table-column--header">
+                  Hi!
+                </div>
+              </div>
+            </th>
+          </tr>
+        </thead>
+        <!-- table stuffs -->
+      </table>
+    </div>
+  </div>
+</div>
+\`\`\`
+
+It's quite beautiful, huh? To help with styling, \`style\` and \`className\` props have been exposed on the \`DataTable\`
+and \`TableColumn\` components to help with this. In addition, there is a
+[react-md-make-fixed-table](/components/data-tables?tab=2#mixin-react-md-make-fixed-table) mixin to help making your fixed
+table to a specific size.
   `,
   code: ConfigurableTableExampleRaw,
   children: <ConfigurableTableExample />,

--- a/docs/src/shared/components/ReactMD/menus/GoogleDocsClone/DropDownMenu.jsx
+++ b/docs/src/shared/components/ReactMD/menus/GoogleDocsClone/DropDownMenu.jsx
@@ -1,13 +1,12 @@
 import React, { PureComponent, PropTypes } from 'react';
 import cn from 'classnames';
-import Menu from 'react-md/lib/Menus/Menu';
+import DropdownMenu from 'react-md/lib/Menus/DropdownMenu';
 import AccessibleFakeInkedButton from 'react-md/lib/Helpers/AccessibleFakeInkedButton';
-import mapToListParts from 'react-md/lib/utils/mapToListParts';
 
 import toClassName from 'utils/StringUtils/toClassName';
 const anchor = {
-  x: Menu.HorizontalAnchors.INNER_LEFT,
-  y: Menu.VerticalAnchors.BOTTOM,
+  x: DropdownMenu.HorizontalAnchors.INNER_LEFT,
+  y: DropdownMenu.VerticalAnchors.BOTTOM,
 };
 
 export default class DropDownMenu extends PureComponent {
@@ -24,12 +23,8 @@ export default class DropDownMenu extends PureComponent {
     this.state = { mouseover: false, visible: false };
   }
 
-  _toggle = () => {
-    this.setState({ visible: true });
-  };
-
-  _close = () => {
-    this.setState({ visible: false });
+  _handleVisibilityChange = (visible) => {
+    this.setState({ visible });
   };
 
   _handleMouseOver = () => {
@@ -44,36 +39,31 @@ export default class DropDownMenu extends PureComponent {
     const { text, items, ...props } = this.props;
     const { mouseover, visible } = this.state;
 
-    const toggle = (
-      <AccessibleFakeInkedButton
-        className={cn('google-docs-dd-menu', {
-          'md-btn--hover': mouseover,
-          'md-paper md-paper--2': visible,
-        })}
-        onClick={this._toggle}
-        onMouseOver={this._handleMouseOver}
-        onMouseLeave={this._handleMouseLeave}
-        tabbedClassName="md-btn--hover"
-      >
-        {text}
-      </AccessibleFakeInkedButton>
-    );
-
     return (
-      <Menu
+      <DropdownMenu
         {...props}
         id={`doc-control-${toClassName(text)}`}
         listClassName="google-docs-list"
-        anchor={anchor}
+        belowAnchor={anchor}
         cascading
         visible={visible}
-        toggle={toggle}
-        onClose={this._close}
-        position={Menu.Positions.BELOW}
+        onVisibilityChange={this._handleVisibilityChange}
+        position={DropdownMenu.Positions.BELOW}
         listHeightRestricted={false}
+        menuItems={items}
       >
-        {items.map(mapToListParts)}
-      </Menu>
+        <AccessibleFakeInkedButton
+          className={cn('google-docs-dd-menu', {
+            'md-btn--hover': mouseover,
+            'md-paper md-paper--2': visible,
+          })}
+          onMouseOver={this._handleMouseOver}
+          onMouseLeave={this._handleMouseLeave}
+          tabbedClassName="md-btn--hover"
+        >
+          {text}
+        </AccessibleFakeInkedButton>
+      </DropdownMenu>
     );
   }
 }

--- a/src/js/DataTables/DataTable.js
+++ b/src/js/DataTables/DataTable.js
@@ -256,6 +256,10 @@ export default class DataTable extends PureComponent {
     return all;
   }
 
+  _setTable = (table) => {
+    this._table = table;
+  };
+
   _createCheckbox = (index) => {
     this.setState((state, props) => {
       const selectedRows = state.selectedRows.slice();
@@ -283,7 +287,7 @@ export default class DataTable extends PureComponent {
     let selectedRows;
     let allSelected = this.state.allSelected;
     let selectedCount = 0;
-    const i = this.state.header ? row - 1 : row;
+    const i = this._table && this._table.querySelector('.md-table-header') ? row - 1 : row;
     const { checked } = e.target;
     if (header) {
       selectedRows = this.state.selectedRows.map(() => checked);

--- a/src/js/DataTables/DataTable.js
+++ b/src/js/DataTables/DataTable.js
@@ -162,6 +162,9 @@ export default class DataTable extends PureComponent {
       PropTypes.func,
       PropTypes.string,
     ]).isRequired,
+
+    fixedHeader: PropTypes.bool,
+    fixedFooter: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -173,6 +176,8 @@ export default class DataTable extends PureComponent {
     selectableRows: true,
     checkboxHeaderLabel: 'Toggle All Rows',
     checkboxLabelTemplate: 'Toggle row {{row}}',
+    fixedHeader: false,
+    fixedFooter: false,
   };
 
   static childContextTypes = contextTypes;
@@ -205,6 +210,8 @@ export default class DataTable extends PureComponent {
       selectableRows,
       checkboxHeaderLabel,
       checkboxLabelTemplate,
+      fixedHeader,
+      fixedFooter,
     } = this.props;
 
     return {
@@ -226,6 +233,8 @@ export default class DataTable extends PureComponent {
       selectableRows,
       checkboxHeaderLabel,
       checkboxLabelTemplate,
+      fixedHeader,
+      fixedFooter,
     };
   }
 
@@ -305,6 +314,8 @@ export default class DataTable extends PureComponent {
       children,
       plain,
       responsive,
+      fixedHeader,
+      fixedFooter,
       /* eslint-disable no-unused-vars */
       checkedIconChildren,
       checkedIconClassName,
@@ -341,9 +352,30 @@ export default class DataTable extends PureComponent {
       return table;
     }
 
+    let content = table;
+    if (fixedHeader || fixedFooter) {
+      content = (
+        <div
+          className={cn('md-data-table__fixed-wrapper', {
+            'md-data-table__fixed-wrapper--header': fixedHeader,
+            'md-data-table__fixed-wrapper--footer': fixedFooter,
+          })}
+        >
+          <div className="md-data-table__scroll-wrapper">
+            {table}
+          </div>
+        </div>
+      );
+    }
+
     return (
-      <div style={style} className={cn('md-data-table--responsive', className)}>
-        {table}
+      <div
+        style={style}
+        className={cn('md-data-table--responsive', {
+          'md-data-table--fixed': fixedHeader || fixedFooter,
+        }, className)}
+      >
+        {content}
       </div>
     );
   }

--- a/src/js/DataTables/DataTable.js
+++ b/src/js/DataTables/DataTable.js
@@ -239,8 +239,8 @@ export default class DataTable extends PureComponent {
     fixedDividers: PropTypes.oneOfType([
       PropTypes.bool,
       PropTypes.shape({
-        header: PropTypes.bool.isRequired,
-        footer: PropTypes.bool.isRequired,
+        header: PropTypes.bool,
+        footer: PropTypes.bool,
       }),
     ]),
 
@@ -249,7 +249,7 @@ export default class DataTable extends PureComponent {
      * the related `react-md-make-fixed-table` mixin instead.
      *
      * @see {@link #headerHeight}
-     * @see {@link #columnHeight}
+     * @see {@link #footerHeight}
      */
     fixedHeight: PropTypes.number,
 
@@ -275,7 +275,7 @@ export default class DataTable extends PureComponent {
      * @see [md-data-table-column-height](/components/data-tables?tab=2#variable-md-data-table-column-height)
      * @see {@link fixedHeight}
      */
-    columnHeight: PropTypes.number.isRequired,
+    footerHeight: PropTypes.number.isRequired,
   };
 
   static defaultProps = {
@@ -291,7 +291,7 @@ export default class DataTable extends PureComponent {
     fixedFooter: false,
     fixedDividers: true,
     headerHeight: 56,
-    columnHeight: 48,
+    footerHeight: 48,
   };
 
   static childContextTypes = contextTypes;
@@ -442,7 +442,7 @@ export default class DataTable extends PureComponent {
       fixedHeight,
       fixedWidth,
       headerHeight,
-      columnHeight,
+      footerHeight,
       /* eslint-disable no-unused-vars */
       checkedIconChildren,
       checkedIconClassName,
@@ -489,8 +489,18 @@ export default class DataTable extends PureComponent {
         }
 
         if (fixedFooter) {
-          height -= columnHeight;
+          height -= footerHeight;
         }
+      }
+
+      let borderTop = fixedHeader;
+      let borderBot = fixedFooter;
+      if (typeof fixedDividers === 'boolean') {
+        borderTop = borderTop && fixedDividers;
+        borderBot = borderBot && fixedDividers;
+      } else {
+        borderTop = borderTop && (typeof fixedDividers.header === 'undefined' || fixedDividers.header);
+        borderBot = borderBot && (typeof fixedDividers.footer === 'undefined' || fixedDividers.footer);
       }
 
       content = (
@@ -505,8 +515,8 @@ export default class DataTable extends PureComponent {
             style={{ height, ...fixedScrollWrapperStyle }}
             className={cn('md-data-table__scroll-wrapper', {
               'md-divider-border': fixedDividers,
-              'md-divider-border--top': fixedHeader && (fixedDividers === true || fixedDividers.header),
-              'md-divider-border--bottom': fixedFooter && (fixedDividers === true || fixedDividers.footer),
+              'md-divider-border--top': borderTop,
+              'md-divider-border--bottom': borderBot,
             }, fixedScrollWrapperClassName)}
           >
             {table}

--- a/src/js/DataTables/EditDialog.js
+++ b/src/js/DataTables/EditDialog.js
@@ -33,6 +33,7 @@ export default class EditDialog extends PureComponent {
     large: PropTypes.bool,
     actions: Dialog.propTypes.actions,
     dialogZDepth: PropTypes.number,
+    header: PropTypes.bool,
   };
 
   render() {
@@ -44,6 +45,7 @@ export default class EditDialog extends PureComponent {
       dialogContentClassName,
       textFieldId,
       visible,
+      header,
       onOpen,
       children,
       label,
@@ -58,7 +60,8 @@ export default class EditDialog extends PureComponent {
     const field = (
       <AccessibleFakeButton
         className={cn('md-edit-dialog__label', {
-          'md-text--secondary': placeholder,
+          'md-edit-dialog__header': header,
+          'md-text--secondary': placeholder || header,
         })}
         noFocusOutline={visible}
         onClick={onOpen}
@@ -86,7 +89,7 @@ export default class EditDialog extends PureComponent {
           contentClassName={cn('md-edit-dialog__content', dialogContentClassName)}
           title={large ? title : null}
           focusOnMount
-          containFocus={large}
+          containFocus={!!large}
           paddedContent={false}
           actions={large ? actions : null}
           zDepth={dialogZDepth}

--- a/src/js/DataTables/EditDialogColumn.js
+++ b/src/js/DataTables/EditDialogColumn.js
@@ -15,6 +15,7 @@ import TextField from '../TextFields/TextField';
 import TableColumn from './TableColumn';
 import EditDialog from './EditDialog';
 import findTable from './findTable';
+import findFixedTo from './findFixedTo';
 
 /**
  * The `EditDialogColumn` is used when there should be used when a table column's value
@@ -455,6 +456,7 @@ export default class EditDialogColumn extends PureComponent {
   componentDidMount() {
     this._column = findDOMNode(this);
     this._table = findTable(this._column);
+    this._fixedTo = findFixedTo(this._table);
 
     // If a developer creates their own component to wrap the EditDialogColumn, the cellIndex prop
     // might not be defined if they don't pass ...props
@@ -726,7 +728,7 @@ export default class EditDialogColumn extends PureComponent {
           yThreshold={yThreshold}
           centered={centered}
           sameWidth={sameWidth}
-          fixedTo={typeof fixedTo !== 'undefined' ? fixedTo : this._table}
+          fixedTo={typeof fixedTo !== 'undefined' ? fixedTo : this._fixedTo}
           dialogZDepth={dialogZDepth}
           transitionName={transitionName}
           transitionEnterTimeout={transitionEnterTimeout}

--- a/src/js/DataTables/EditDialogColumn.js
+++ b/src/js/DataTables/EditDialogColumn.js
@@ -389,6 +389,21 @@ export default class EditDialogColumn extends PureComponent {
     transitionLeaveTimeout: PropTypes.number,
 
     /**
+     * The optional tooltip to render on hover.
+     */
+    tooltipLabel: PropTypes.string,
+
+    /**
+     * An optional delay to apply to the tooltip before it appears.
+     */
+    tooltipDelay: PropTypes.number,
+
+    /**
+     * The position of the tooltip.
+     */
+    tooltipPosition: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
+
+    /**
      * This is injected by the `TableRow` component.
      * @access private
      */
@@ -632,6 +647,9 @@ export default class EditDialogColumn extends PureComponent {
       transitionName,
       transitionEnterTimeout,
       transitionLeaveTimeout,
+      tooltipLabel,
+      tooltipDelay,
+      tooltipPosition,
       /* eslint-disable no-unused-vars */
       id: propId,
       dialogId: propDialogId,
@@ -684,7 +702,10 @@ export default class EditDialogColumn extends PureComponent {
         ref={this._setField}
         style={textFieldStyle}
         className={cn({ 'md-edit-dialog__blocked-field': inline }, textFieldClassName)}
-        inputClassName={cn({ 'md-text-right': numeric }, inputClassName)}
+        inputClassName={cn({
+          'md-text--secondary md-edit-dialog__header': header && inline,
+          'md-text-right': numeric,
+        }, inputClassName)}
         id={id}
         label={label}
         placeholder={placeholder}
@@ -720,6 +741,7 @@ export default class EditDialogColumn extends PureComponent {
           actions={actions}
           large={large}
           title={title}
+          header={header}
           placeholder={dialogLabel === placeholder || dialogLabel === label}
           anchor={anchor}
           belowAnchor={belowAnchor}
@@ -746,6 +768,9 @@ export default class EditDialogColumn extends PureComponent {
         className={cn('md-edit-dialog-column', className)}
         header={header}
         adjusted={false}
+        tooltipLabel={tooltipLabel}
+        tooltipDelay={tooltipDelay}
+        tooltipPosition={tooltipPosition}
       >
         {children}
       </TableColumn>

--- a/src/js/DataTables/SelectFieldColumn.js
+++ b/src/js/DataTables/SelectFieldColumn.js
@@ -97,6 +97,27 @@ export default class SelectFieldColumn extends PureComponent {
      */
     adjusted: PropTypes.bool,
 
+    /**
+     * The optional tooltip to render on hover.
+     *
+     * @see {@link DataTables/TableColumn#tooltipLabel}
+     */
+    tooltipLabel: PropTypes.string,
+
+    /**
+     * An optional delay to apply to the tooltip before it appears.
+     *
+     * @see {@link DataTables/TableColumn#tooltipDelay}
+     */
+    tooltipDelay: PropTypes.number,
+
+    /**
+     * The position of the tooltip.
+     *
+     * @see {@link DataTables/TableColumn#tooltipPosition}
+     */
+    tooltipPosition: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
+
     wrapperStyle: deprecated(PropTypes.object, 'There is no longer a wrapper'),
     wrapperClassName: deprecated(PropTypes.string, 'There is no longer a wrapper'),
   };
@@ -141,6 +162,9 @@ export default class SelectFieldColumn extends PureComponent {
       menuClassName,
       header,
       fixedTo,
+      tooltipLabel,
+      tooltipDelay,
+      tooltipPosition,
       /* eslint-disable no-unused-vars */
       id: propId,
       cellIndex: propCellIndex,
@@ -164,6 +188,9 @@ export default class SelectFieldColumn extends PureComponent {
         style={style}
         className={cn('md-select-field-column', className)}
         adjusted={false}
+        tooltipLabel={tooltipLabel}
+        tooltipDelay={tooltipDelay}
+        tooltipPosition={tooltipPosition}
       >
         <SelectField
           {...props}

--- a/src/js/DataTables/SelectFieldColumn.js
+++ b/src/js/DataTables/SelectFieldColumn.js
@@ -8,6 +8,7 @@ import fixedToShape from '../Helpers/fixedToShape';
 import positionShape from '../Helpers/positionShape';
 import SelectField from '../SelectFields/SelectField';
 import findTable from './findTable';
+import findFixedTo from './findFixedTo';
 import TableColumn from './TableColumn';
 
 /**
@@ -112,23 +113,23 @@ export default class SelectFieldColumn extends PureComponent {
     ]),
   }
 
-  state = { table: undefined, cellIndex: undefined };
+  state = { cellIndex: undefined };
 
   componentDidMount() {
     const { cellIndex } = this.props;
     const column = findDOMNode(this);
     const table = findTable(column);
-
-    const state = { table };
+    this._fixedTo = findFixedTo(table);
 
     // If a developer creates their own component to wrap the EditDialogColumn, the cellIndex prop
     // might not be defined if they don't pass ...props
     if (!cellIndex && cellIndex !== 0) {
       const columns = [].slice.call(column.parentNode.querySelectorAll('th,td'));
-      state.cellIndex = columns.indexOf(column);
+      this.setState({ cellIndex: columns.indexOf(column) }); // eslint-disable-line react/no-did-mount-set-state
+    } else {
+      // need to apply the _fixedTo for the select field
+      this.forceUpdate();
     }
-
-    this.setState(state); // eslint-disable-line react/no-did-mount-set-state
   }
 
   render() {
@@ -167,7 +168,7 @@ export default class SelectFieldColumn extends PureComponent {
         <SelectField
           {...props}
           id={id}
-          fixedTo={fixedTo || this.state.table}
+          fixedTo={fixedTo || this._fixedTo}
           style={menuStyle}
           className={menuClassName}
         />

--- a/src/js/DataTables/TableCheckbox.js
+++ b/src/js/DataTables/TableCheckbox.js
@@ -16,7 +16,6 @@ export default class TableCheckbox extends Component {
       PropTypes.string,
     ]).isRequired,
     baseName: PropTypes.string.isRequired,
-    header: PropTypes.bool,
     indeterminate: PropTypes.bool,
     checkedIconChildren: PropTypes.node,
     checkedIconClassName: PropTypes.string,
@@ -31,6 +30,8 @@ export default class TableCheckbox extends Component {
     ]).isRequired,
     createCheckbox: PropTypes.func.isRequired,
     removeCheckbox: PropTypes.func.isRequired,
+    header: PropTypes.bool,
+    footer: PropTypes.bool,
     fixedHeader: PropTypes.bool.isRequired,
     fixedFooter: PropTypes.bool.isRequired,
   };
@@ -72,6 +73,7 @@ export default class TableCheckbox extends Component {
       indeterminateIconClassName,
       indeterminate,
       header,
+      footer,
       rowId,
       baseName,
       checkboxHeaderLabel,
@@ -103,17 +105,22 @@ export default class TableCheckbox extends Component {
       />
     );
     const fixedHeader = header && this.context.fixedHeader;
+    const fixedFooter = footer && this.context.fixedFooter;
 
     if (fixedHeader) {
       content = (
         <div
           className={cn('md-table-column__fixed', {
             'md-table-column__fixed--header': fixedHeader,
+            'md-table-column__fixed--footer': fixedFooter,
           })}
         >
-          <div className="md-table-checkbox--fixed">
-            {content}
-          </div>
+          {React.cloneElement(content, {
+            className: cn({
+              'md-table-checkbox--header': header,
+              'md-table-checkbox--footer': footer,
+            }),
+          })}
         </div>
       );
     }

--- a/src/js/DataTables/TableCheckbox.js
+++ b/src/js/DataTables/TableCheckbox.js
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from 'react';
+import cn from 'classnames';
 import SelectionControl from '../SelectionControls/SelectionControl';
 
 import findTable from './findTable';
@@ -30,6 +31,8 @@ export default class TableCheckbox extends Component {
     ]).isRequired,
     createCheckbox: PropTypes.func.isRequired,
     removeCheckbox: PropTypes.func.isRequired,
+    fixedHeader: PropTypes.bool.isRequired,
+    fixedFooter: PropTypes.bool.isRequired,
   };
 
   constructor(props, context) {
@@ -85,20 +88,45 @@ export default class TableCheckbox extends Component {
       label = checkboxLabelTemplate.replace(/{{row}}/g, index);
     }
 
+    let content = (
+      <SelectionControl
+        {...props}
+        id={rowId}
+        name={`${baseName}-checkbox`}
+        type="checkbox"
+        checked={checked}
+        uncheckedCheckboxIconChildren={header && indeterminate ? indeterminateIconChildren : uncheckedIconChildren}
+        uncheckedCheckboxIconClassName={header && indeterminate ? indeterminateIconClassName : uncheckedIconClassName}
+        checkedCheckboxIconChildren={checkedIconChildren}
+        checkedCheckboxIconClassName={checkedIconClassName}
+        aria-label={label}
+      />
+    );
+    const fixedHeader = header && this.context.fixedHeader;
+
+    if (fixedHeader) {
+      content = (
+        <div
+          className={cn('md-table-column__fixed', {
+            'md-table-column__fixed--header': fixedHeader,
+          })}
+        >
+          <div className="md-table-checkbox--fixed">
+            {content}
+          </div>
+        </div>
+      );
+    }
+
     return (
-      <Cell className="md-table-checkbox" scope={header ? 'col' : undefined} ref={this._handleMount}>
-        <SelectionControl
-          {...props}
-          id={rowId}
-          name={`${baseName}-checkbox`}
-          type="checkbox"
-          checked={checked}
-          uncheckedCheckboxIconChildren={header && indeterminate ? indeterminateIconChildren : uncheckedIconChildren}
-          uncheckedCheckboxIconClassName={header && indeterminate ? indeterminateIconClassName : uncheckedIconClassName}
-          checkedCheckboxIconChildren={checkedIconChildren}
-          checkedCheckboxIconClassName={checkedIconClassName}
-          aria-label={label}
-        />
+      <Cell
+        className={cn('md-table-checkbox', {
+          'md-table-column--fixed': fixedHeader,
+        })}
+        scope={header ? 'col' : undefined}
+        ref={this._handleMount}
+      >
+        {content}
       </Cell>
     );
   }

--- a/src/js/DataTables/TableColumn.js
+++ b/src/js/DataTables/TableColumn.js
@@ -223,8 +223,6 @@ class TableColumn extends PureComponent {
             style={fixedStyle}
             className={cn(baseClassNames, mergedClassNames, 'md-table-column__fixed--flex', {
               'md-table-column__fixed--flex-right': numeric,
-              'md-table-column--relative': tooltip,
-              'md-table-column--select-field': selectColumnHeader,
             }, fixedClassName)}
           >
             {tooltip}

--- a/src/js/DataTables/TableColumn.js
+++ b/src/js/DataTables/TableColumn.js
@@ -146,8 +146,8 @@ class TableColumn extends PureComponent {
   static contextTypes = {
     plain: PropTypes.bool,
     footer: PropTypes.bool,
-    fixedHeader: PropTypes.bool.isRequired,
-    fixedFooter: PropTypes.bool.isRequired,
+    fixedHeader: PropTypes.bool,
+    fixedFooter: PropTypes.bool,
   };
 
   render() {
@@ -193,6 +193,14 @@ class TableColumn extends PureComponent {
 
     const fixedHeader = header && this.context.fixedHeader;
     const fixedFooter = this.context.footer && this.context.fixedFooter;
+    const fixed = fixedHeader || fixedFooter;
+    const baseClassNames = cn({
+      'md-text': !header,
+      'md-text--secondary': header,
+      'md-table-column--relative': tooltip,
+      'md-table-column--select-field': selectColumnHeader,
+    });
+
     const mergedClassNames = cn({
       'md-table-column--header': header,
       'md-table-column--data': !header && !plain,
@@ -200,15 +208,10 @@ class TableColumn extends PureComponent {
       'md-table-column--adjusted': adjusted && !grow && !selectColumnHeader,
       'md-table-column--grow': grow,
       'md-table-column--sortable md-pointer--hover': sortable,
-      'md-table-column--relative': tooltip && !fixedHeader && !fixedFooter,
-      'md-table-column--select-field': selectColumnHeader && !fixedHeader && !fixedFooter,
-      'md-text': !header,
-      'md-text--secondary': header,
-      'md-text-left': !numeric,
-      'md-text-right': numeric,
+      [baseClassNames]: !fixed,
     }, className);
 
-    if (fixedHeader || fixedFooter) {
+    if (fixed) {
       displayedChildren = (
         <div
           className={cn('md-table-column__fixed', {
@@ -218,7 +221,8 @@ class TableColumn extends PureComponent {
         >
           <div
             style={fixedStyle}
-            className={cn(mergedClassNames, {
+            className={cn(baseClassNames, mergedClassNames, 'md-table-column__fixed--flex', {
+              'md-table-column__fixed--flex-right': numeric,
               'md-table-column--relative': tooltip,
               'md-table-column--select-field': selectColumnHeader,
             }, fixedClassName)}
@@ -236,7 +240,9 @@ class TableColumn extends PureComponent {
         {...props}
         scope={scope}
         className={cn('md-table-column', {
-          'md-table-column--fixed': fixedHeader || fixedFooter,
+          'md-table-column--fixed': fixed,
+          'md-text-left': !numeric && !fixed,
+          'md-text-right': numeric && !fixed,
         }, mergedClassNames)}
       >
         {!fixedHeader && !fixedFooter && tooltip}

--- a/src/js/DataTables/TableColumn.js
+++ b/src/js/DataTables/TableColumn.js
@@ -29,6 +29,18 @@ class TableColumn extends PureComponent {
     className: PropTypes.string,
 
     /**
+     * An optional style to apply to the surroudning div when the DataTable has been
+     * set to include a fixed header or a fixed footer.
+     */
+    fixedStyle: PropTypes.object,
+
+    /**
+     * An optional className to apply to the surroudning div when the DataTable has been
+     * set to include a fixed header or a fixed footer.
+     */
+    fixedClassName: PropTypes.string,
+
+    /**
      * The children to display in the column.
      */
     children: PropTypes.node,
@@ -133,11 +145,16 @@ class TableColumn extends PureComponent {
 
   static contextTypes = {
     plain: PropTypes.bool,
+    footer: PropTypes.bool,
+    fixedHeader: PropTypes.bool.isRequired,
+    fixedFooter: PropTypes.bool.isRequired,
   };
 
   render() {
     const {
       className,
+      fixedStyle,
+      fixedClassName,
       numeric,
       header,
       children,
@@ -174,27 +191,55 @@ class TableColumn extends PureComponent {
       );
     }
 
+    const fixedHeader = header && this.context.fixedHeader;
+    const fixedFooter = this.context.footer && this.context.fixedFooter;
+    const mergedClassNames = cn({
+      'md-table-column--header': header,
+      'md-table-column--data': !header && !plain,
+      'md-table-column--plain': !header && plain,
+      'md-table-column--adjusted': adjusted && !grow && !selectColumnHeader,
+      'md-table-column--grow': grow,
+      'md-table-column--sortable md-pointer--hover': sortable,
+      'md-table-column--relative': tooltip && !fixedHeader && !fixedFooter,
+      'md-table-column--select-field': selectColumnHeader && !fixedHeader && !fixedFooter,
+      'md-text': !header,
+      'md-text--secondary': header,
+      'md-text-left': !numeric,
+      'md-text-right': numeric,
+    }, className);
+
+    if (fixedHeader || fixedFooter) {
+      displayedChildren = (
+        <div
+          className={cn('md-table-column__fixed', {
+            'md-table-column__fixed--header': fixedHeader,
+            'md-table-column__fixed--footer': fixedFooter,
+          })}
+        >
+          <div
+            style={fixedStyle}
+            className={cn(mergedClassNames, {
+              'md-table-column--relative': tooltip,
+              'md-table-column--select-field': selectColumnHeader,
+            }, fixedClassName)}
+          >
+            {tooltip}
+            {displayedChildren}
+          </div>
+        </div>
+      );
+    }
+
     return (
       <Component
         aria-sort={ariaSort}
         {...props}
         scope={scope}
         className={cn('md-table-column', {
-          'md-table-column--header': header,
-          'md-table-column--data': !header && !plain,
-          'md-table-column--plain': !header && plain,
-          'md-table-column--adjusted': adjusted && !grow && !selectColumnHeader,
-          'md-table-column--grow': grow,
-          'md-table-column--sortable md-pointer--hover': sortable,
-          'md-table-column--relative': tooltip,
-          'md-table-column--select-field': selectColumnHeader,
-          'md-text': !header,
-          'md-text--secondary': header,
-          'md-text-left': !numeric,
-          'md-text-right': numeric,
-        }, className)}
+          'md-table-column--fixed': fixedHeader || fixedFooter,
+        }, mergedClassNames)}
       >
-        {tooltip}
+        {!fixedHeader && !fixedFooter && tooltip}
         {displayedChildren}
       </Component>
     );

--- a/src/js/DataTables/TableFooter.jsx
+++ b/src/js/DataTables/TableFooter.jsx
@@ -1,0 +1,27 @@
+import React, { PureComponent, PropTypes } from 'react';
+import cn from 'classnames';
+
+export default class TableFooter extends PureComponent {
+  static propTypes = {
+    className: PropTypes.string,
+    children: PropTypes.node,
+  };
+
+  static childContextTypes = {
+    footer: PropTypes.bool,
+  }
+
+  getChildContext() {
+    return { footer: true };
+  }
+
+  render() {
+    const { className, children, ...props } = this.props;
+
+    return (
+      <tfoot className={cn('md-table-footer', className)} {...props}>
+        {children}
+      </tfoot>
+    );
+  }
+}

--- a/src/js/DataTables/TableRow.js
+++ b/src/js/DataTables/TableRow.js
@@ -64,6 +64,12 @@ export default class TableRow extends Component {
      */
     selected: PropTypes.bool,
 
+    /**
+     * Boolean if the current row is selectable. This value will take precedence over anything inherited
+     * by the `DataTable`.
+     */
+    selectable: PropTypes.bool,
+
     autoAdjust: deprecated(PropTypes.bool, 'Manually specify `grow` on one of the columns instead'),
   };
 
@@ -148,6 +154,7 @@ export default class TableRow extends Component {
       className,
       children,
       selected,
+      selectable,
       /* eslint-disable no-unused-vars */
       onCheckboxClick,
       // deprecated
@@ -159,7 +166,7 @@ export default class TableRow extends Component {
     const { hover } = this.state;
 
     let checkbox;
-    if (!this.context.plain && this.context.selectableRows) {
+    if (typeof selectable !== 'undefined' ? selectable : (!this.context.plain && this.context.selectableRows)) {
       checkbox = (
         <TableCheckbox
           key="checkbox"

--- a/src/js/DataTables/__tests__/DataTable.js
+++ b/src/js/DataTables/__tests__/DataTable.js
@@ -1,5 +1,5 @@
 /* eslint-env jest*/
-/* eslint-disable react/no-multi-comp */
+/* eslint-disable react/no-multi-comp,max-len */
 import React from 'react';
 import { mount, shallow } from 'enzyme';
 import { findDOMNode } from 'react-dom';
@@ -331,5 +331,116 @@ describe('DataTable', () => {
     state = findTableState(table);
     expected = [false, false, false];
     expect(state.selectedRows).toEqual(expected);
+  });
+
+  it('should add additional wrappers when either the fixedHeader or fixedFooter prop has been enabled.', () => {
+    const table = shallow(
+      <DataTable baseId="woop" fixedHeader>
+        <tbody><tr><td>woop</td></tr></tbody>
+      </DataTable>
+    );
+
+    expect(table.hasClass('md-data-table--responsive')).toBe(true);
+    expect(table.hasClass('md-data-table--fixed')).toBe(true);
+
+    expect(table.find('.md-data-table__fixed-wrapper').length).toBe(1);
+    expect(table.find('.md-data-table__scroll-wrapper').length).toBe(1);
+  });
+
+  it('should add the divider borders to the scroll wrapper when enabled', () => {
+    const table = shallow(
+      <DataTable baseId="woop" fixedHeader fixedFooter>
+        <tbody><tr><td>woop</td></tr></tbody>
+      </DataTable>
+    );
+
+    expect(table.find('.md-divider-border').length).toBe(1);
+    expect(table.find('.md-divider-border--top').length).toBe(1);
+    expect(table.find('.md-divider-border--bottom').length).toBe(1);
+
+    table.setProps({ fixedFooter: false });
+    expect(table.find('.md-divider-border').length).toBe(1);
+    expect(table.find('.md-divider-border--top').length).toBe(1);
+    expect(table.find('.md-divider-border--bottom').length).toBe(0);
+
+    table.setProps({ fixedHeader: false, fixedFooter: true });
+    expect(table.find('.md-divider-border').length).toBe(1);
+    expect(table.find('.md-divider-border--top').length).toBe(0);
+    expect(table.find('.md-divider-border--bottom').length).toBe(1);
+
+    table.setProps({ fixedHeader: false, fixedFooter: false });
+    expect(table.find('.md-divider-border').length).toBe(0);
+    expect(table.find('.md-divider-border--top').length).toBe(0);
+    expect(table.find('.md-divider-border--bottom').length).toBe(0);
+  });
+
+  it('should not apply the divider class names when the fixedDividers prop is set to false', () => {
+    const table = shallow(
+      <DataTable baseId="woop" fixedHeader fixedFooter fixedDividers={false}>
+        <tbody><tr><td>woop</td></tr></tbody>
+      </DataTable>
+    );
+    expect(table.find('.md-divider-border').length).toBe(0);
+    expect(table.find('.md-divider-border--top').length).toBe(0);
+    expect(table.find('.md-divider-border--bottom').length).toBe(0);
+  });
+
+  it('should not apply the divider classNames when the fixedDividers prop is set to false for either header or footer', () => {
+    const table = shallow(
+      <DataTable baseId="woop" fixedHeader fixedFooter fixedDividers={{ header: true, footer: false }}>
+        <tbody><tr><td>woop</td></tr></tbody>
+      </DataTable>
+    );
+    expect(table.find('.md-divider-border').length).toBe(1);
+    expect(table.find('.md-divider-border--top').length).toBe(1);
+    expect(table.find('.md-divider-border--bottom').length).toBe(0);
+
+    table.setProps({ fixedDividers: { header: false, footer: true } });
+    expect(table.find('.md-divider-border').length).toBe(1);
+    expect(table.find('.md-divider-border--top').length).toBe(0);
+    expect(table.find('.md-divider-border--bottom').length).toBe(1);
+
+    table.setProps({ fixedDividers: { header: undefined, footer: true } });
+    expect(table.find('.md-divider-border').length).toBe(1);
+    expect(table.find('.md-divider-border--top').length).toBe(1);
+    expect(table.find('.md-divider-border--bottom').length).toBe(1);
+
+    table.setProps({ fixedDividers: { header: true, footer: undefined } });
+    expect(table.find('.md-divider-border').length).toBe(1);
+    expect(table.find('.md-divider-border--top').length).toBe(1);
+    expect(table.find('.md-divider-border--bottom').length).toBe(1);
+  });
+
+  it('should apply the fixedWidth to the main responsive wrapper', () => {
+    const table = mount(
+      <DataTable baseId="woop" fixedHeader fixedFooter fixedWidth={300}>
+        <tbody><tr><td>woop</td></tr></tbody>
+      </DataTable>
+    );
+
+    expect(table.getDOMNode().style.width).toBe('300px');
+  });
+
+  it('should apply the fixedHeight prop to the scroll container and correctly subtract the header and footer if enabled', () => {
+    const headerHeight = 50;
+    const footerHeight = 40;
+    const table = mount(
+      <DataTable baseId="woop" fixedHeader fixedFooter fixedHeight={500} headerHeight={headerHeight} footerHeight={footerHeight}>
+        <tbody><tr><td>woop</td></tr></tbody>
+      </DataTable>
+    );
+
+    const getHeight = (t) => t.find('.md-data-table__scroll-wrapper').get(0).style.height;
+
+    let height = getHeight(table);
+    expect(height).toBe('410px');
+
+    table.setProps({ fixedFooter: false });
+    height = getHeight(table);
+    expect(height).toBe('450px');
+
+    table.setProps({ fixedFooter: true, fixedHeader: false });
+    height = getHeight(table);
+    expect(height).toBe('460px');
   });
 });

--- a/src/js/DataTables/__tests__/TableColumn.js
+++ b/src/js/DataTables/__tests__/TableColumn.js
@@ -8,6 +8,11 @@ import {
   scryRenderedDOMComponentsWithTag,
 } from 'react-addons-test-utils';
 
+import DataTable from '../DataTable';
+import TableHeader from '../TableHeader';
+import TableBody from '../TableBody';
+import TableFooter from '../TableFooter';
+import TableRow from '../TableRow';
 import TableColumn from '../TableColumn';
 import Collapser from '../../FontIcons/Collapser';
 import IconSeparator from '../../Helpers/IconSeparator';
@@ -276,5 +281,48 @@ describe('TableColumn', () => {
       </table>
     );
     expect(table.find('td').at(0).props().scope).toBeUndefined();
+  });
+
+  it('should update the classname when the DataTable is fixed only for the header or footer', () => {
+    const table = mount(
+      <DataTable baseId="woop" fixedHeader fixedFooter>
+        <TableHeader>
+          <TableRow>
+            <TableColumn id="head" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow>
+            <TableColumn id="body" />
+          </TableRow>
+        </TableBody>
+        <TableFooter>
+          <TableRow>
+            <TableColumn id="foot" />
+          </TableRow>
+        </TableFooter>
+      </DataTable>
+    );
+
+    expect(table.find('#head').hasClass('md-table-column--fixed')).toBe(true);
+    expect(table.find('#body').hasClass('md-table-column--fixed')).toBe(false);
+    expect(table.find('#foot').hasClass('md-table-column--fixed')).toBe(true);
+  });
+
+  it('should create 2 additional divs for fixed columns', () => {
+    const table = mount(
+      <DataTable baseId="woop" fixedHeader fixedFooter>
+        <TableHeader>
+          <TableRow>
+            <TableColumn id="head" />
+          </TableRow>
+        </TableHeader>
+      </DataTable>
+    );
+
+    const col = table.find(TableColumn);
+    expect(col.find('.md-table-column__fixed').length).toBe(1);
+    expect(col.find('.md-table-column__fixed--header').length).toBe(1);
+    expect(col.find('.md-table-column__fixed--flex').length).toBe(1);
   });
 });

--- a/src/js/DataTables/__tests__/TableRow.js
+++ b/src/js/DataTables/__tests__/TableRow.js
@@ -228,7 +228,7 @@ describe('TableRow', () => {
       const event2 = { target: { checked: false } };
       row1._handleCheckboxClick(false, event2);
       expect(table.state.allSelected).toBe(false);
-      expect(table.state.selectedRows).toEqual([true, false]);
+      expect(table.state.selectedRows).toEqual([false, true]);
     });
   });
 });

--- a/src/js/DataTables/contextTypes.js
+++ b/src/js/DataTables/contextTypes.js
@@ -22,4 +22,6 @@ export default {
   baseName: PropTypes.string,
   checkboxHeaderLabel: PropTypes.string.isRequired,
   checkboxLabelTemplate: PropTypes.string.isRequired,
+  fixedHeader: PropTypes.bool.isRequired,
+  fixedFooter: PropTypes.bool.isRequired,
 };

--- a/src/js/DataTables/findFixedTo.js
+++ b/src/js/DataTables/findFixedTo.js
@@ -1,0 +1,10 @@
+export default function findFixedTo(table) {
+  if (table && table.firstChild.firstChild.classList.contains('md-data-table__scroll-wrapper')) {
+    return {
+      x: table,
+      y: table.firstChild.firstChild,
+    };
+  }
+
+  return table;
+}

--- a/src/js/DataTables/findTable.js
+++ b/src/js/DataTables/findTable.js
@@ -9,14 +9,17 @@ export default function findTable(el) {
   let table;
   let node = el;
   while (node && node.parentNode) {
-    if (node.classList && node.classList.contains('md-data-table')) {
-      // Attempt to check one more element up to see if there is a table-container
-      // for responsive tables.
-      table = node;
-    } else if (node.classList && node.classList.contains('md-data-table--responsive')) {
-      return node;
-    } else if (table) {
-      return table;
+    if (node.classList) {
+      if (node.classList.contains('md-data-table')) {
+        table = node;
+      } else if (node.classList.contains('md-data-table--responsive')) {
+        return node;
+      } else if (node.classList.contains('md-data-table__scroll-wrapper')) {
+        // fixed-wrapper then responsive
+        return node.parentNode.parentNode;
+      } else if (table) {
+        return table;
+      }
     }
 
     node = node.parentNode;

--- a/src/js/TextFields/TextField.js
+++ b/src/js/TextFields/TextField.js
@@ -390,15 +390,15 @@ export default class TextField extends PureComponent {
 
     let currentLength = 0;
     if (typeof props.value !== 'undefined') {
-      currentLength = props.value.length;
+      currentLength = String(props.value).length;
     } else if (typeof props.defaultValue !== 'undefined') {
-      currentLength = props.defaultValue.length;
+      currentLength = String(props.defaultValue).length;
     }
 
     this.state = {
       active: false,
       error: false,
-      floating: !!props.defaultValue || !!props.value,
+      floating: !!props.defaultValue || !!props.value || props.defaultValue === 0 || props.value === 0,
       passwordVisible: props.passwordInitiallyVisible,
       height: null,
       width: props.resize ? props.resize.min : null,
@@ -442,7 +442,7 @@ export default class TextField extends PureComponent {
 
       this.setState({
         error,
-        floating: !!value || (this.state.floating && this.state.active),
+        floating: value === 0 || !!value || (this.state.floating && this.state.active),
         currentLength: value.length,
       });
     }
@@ -617,7 +617,7 @@ export default class TextField extends PureComponent {
 
     const state = { active: false, error: this.props.required && !value };
     if (!this.props.block) {
-      state.floating = !!value;
+      state.floating = !!value || value === 0;
     }
 
     this.setState(state);

--- a/src/js/TextFields/__tests__/TextField.js
+++ b/src/js/TextFields/__tests__/TextField.js
@@ -256,4 +256,12 @@ describe('TextField', () => {
   it('does some stuff that seems hard to automatically test', () => {
     expect(true).toBe(true);
   });
+
+  it('should set to floating state to true when the defaultValue or value is 0', () => {
+    const field = shallow(<TextField id="test" defaultValue={0} type="number" />);
+    expect(field.state('floating')).toBe(true);
+
+    field.setProps({ value: 0, onChange: jest.fn() });
+    expect(field.state('floating')).toBe(true);
+  });
 });

--- a/src/scss/components/_data-tables.scss
+++ b/src/scss/components/_data-tables.scss
@@ -22,6 +22,22 @@ $md-data-table-include-edit-dialog: true !default;
 /// @type Boolean
 $md-data-table-include-select-fields: true !default;
 
+/// Boolean if the styles for fixed table headers/footers should be included.
+/// @type Boolean
+$md-data-table-include-fixed-headers-footers: true !default;
+
+/// Boolean if the `react-md-make-fixed-table` mixin should include headers by default in the
+/// created styles.
+///
+/// @see react-md-make-fixed-table
+$md-data-table-fixed-include-headers: true !default;
+
+/// Boolean if the `react-md-make-fixed-table` mixin should include footers by default in the
+/// created styles.
+///
+/// @see react-md-make-fixed-table
+$md-data-table-fixed-include-footers: false !default;
+
 /// Boolean if the table pagination styles should be included.
 /// @type Boolean
 $md-data-table-include-pagination: true !default;
@@ -109,6 +125,10 @@ $md-data-table-card-header-font-size: 16px !default;
 /// @type Number
 $md-data-table-card-header-height: 80px !default;
 
+/// The min-width to apply to the fixed tables wrapper.
+/// @type Number
+$md-data-table-fixed-wrapper-min-width: 100% !default;
+
 /// A fallback color to use for the contextual table card header. This is only required
 /// when the `$md-primary-color` is not a valid material design color.
 /// @type Color
@@ -157,7 +177,8 @@ $md-data-table-contextual-fallback-color: null !default;
   $include-edit-dialog: $md-data-table-include-edit-dialog,
   $include-select-fields: $md-data-table-include-select-fields,
   $include-pagination: $md-data-table-include-pagination,
-  $include-table-card-headers: $md-data-table-include-table-card-headers
+  $include-table-card-headers: $md-data-table-include-table-card-headers,
+  $include-fixed-headers-footers: $md-data-table-include-fixed-headers-footers
 ) {
   @include react-md-data-table($include-plain);
   @include react-md-data-table-rows($light-theme);
@@ -181,6 +202,10 @@ $md-data-table-contextual-fallback-color: null !default;
 
   @if $include-table-card-headers {
     @include react-md-data-table-card-headers;
+  }
+
+  @if $include-fixed-headers-footers {
+    @include react-md-data-table-fixed-headers-footers;
   }
 }
 
@@ -405,6 +430,105 @@ $md-data-table-contextual-fallback-color: null !default;
       justify-content: flex-start;
       position: absolute;
       white-space: nowrap;
+    }
+  }
+}
+
+@mixin react-md-data-table-fixed-headers-footers {
+  .md-data-table {
+    &--fixed {
+      overflow-y: hidden;
+    }
+
+    &__fixed-wrapper {
+      display: table;
+      min-width: $md-data-table-fixed-wrapper-min-width;
+      position: relative;
+
+      &--header {
+        padding-top: $md-data-table-header-height;
+      }
+
+      &--footer {
+        padding-bottom: $md-data-table-column-height;
+      }
+    }
+
+    &__scroll-wrapper {
+      overflow-x: hidden;
+      overflow-y: auto;
+    }
+  }
+
+  .md-table-column--fixed {
+    height: 0;
+    padding-bottom: 0;
+    padding-top: 0;
+    visibility: hidden;
+    white-space: nowrap;
+
+    > * {
+      display: none;
+    }
+
+    .md-table-column__fixed {
+      display: block;
+    }
+  }
+
+  .md-table-column__fixed {
+    position: absolute;
+    visibility: visible;
+
+    &--header {
+      top: 0;
+    }
+
+    &--footer {
+      bottom: 0;
+    }
+
+    .md-table-column--header {
+      padding-top: $md-data-table-header-height / 2 - $md-data-table-header-font-size / 2;
+    }
+
+    .md-table-column--data {
+      padding-top: $md-data-table-column-height / 2 - $md-data-table-content-font-size / 2;
+    }
+  }
+
+  .md-table-checkbox--fixed {
+    padding-top: 10px;
+  }
+}
+
+///
+/// @example scss - Example Usage
+/// .fixed-table {
+///   @include react-md-make-fixed-table(300px);
+///
+///   width: 200px;
+/// }
+///
+///
+/// @param {Number} height - The height to use for the fixed table.
+/// @param {Number} header-height [$md-data-table-header-height] - The height for the table's header. If this is `null`,
+///     this table should *not* have a fixed header.
+/// @param {Number} footer-height [$md-data-table-column-height] - The height for the table's footer. If this is `null`,
+///     the table should *not* have a fixed footer.
+@mixin react-md-make-fixed-table($height, $header-height: $md-data-table-header-height, $footer-height: $md-data-table-column-height) {
+  $wrapper-height: $height;
+  @if $md-data-table-fixed-include-headers and $header-height != null {
+    $wrapper-height: $wrapper-height - $header-height;
+  }
+
+  @if $md-data-table-fixed-include-footers and $footer-height != null {
+    $wrapper-height: $wrapper-height - $footer-height;
+  }
+
+  @if ($wrapper-height != $height) {
+    .md-data-table__scroll-wrapper {
+      height: $height - $header-height;
     }
   }
 }

--- a/src/scss/components/_data-tables.scss
+++ b/src/scss/components/_data-tables.scss
@@ -439,6 +439,12 @@ $md-data-table-contextual-fallback-color: null !default;
 
 /// Creates the styles for table pagination.
 @mixin react-md-data-table-paginations {
+  .md-table-footer--pagination {
+    .md-table-column {
+      padding-left: 0;
+    }
+  }
+
   .md-table-pagination {
     height: $md-data-table-header-height;
 
@@ -452,6 +458,7 @@ $md-data-table-contextual-fallback-color: null !default;
   }
 }
 
+/// Creates the styles for fixed headers and footers in a data table.
 @mixin react-md-data-table-fixed-headers-footers {
   .md-data-table {
     &--fixed {
@@ -563,7 +570,8 @@ $md-data-table-contextual-fallback-color: null !default;
 /// }
 ///
 ///
-/// @param {Number | Boolean} height - The height to use for the fixed table.
+/// @param {Number | Boolean} height - The height to use for the fixed table. If this value is a boolean, the height
+///     will be calculated from the view height.
 /// @param {Number} header-height [$md-data-table-header-height] - The height for the table's header. If this is `null`,
 ///     this table should *not* have a fixed header.
 /// @param {Number} footer-height [$md-data-table-column-height] - The height for the table's footer. If this is `null`,

--- a/src/scss/components/_data-tables.scss
+++ b/src/scss/components/_data-tables.scss
@@ -36,7 +36,12 @@ $md-data-table-fixed-include-headers: true !default;
 /// created styles.
 ///
 /// @see react-md-make-fixed-table
-$md-data-table-fixed-include-footers: false !default;
+$md-data-table-fixed-include-footers: true !default;
+
+/// Boolean if the `react-md-make-fixed-table` mixin should make the table fixed relative to the
+/// view height instead of just using height.
+/// @type Boolean
+$md-data-table-fixed-use-view-height: false !default;
 
 /// Boolean if the table pagination styles should be included.
 /// @type Boolean
@@ -396,8 +401,21 @@ $md-data-table-contextual-fallback-color: null !default;
       }
     }
 
+    &__header {
+      font-weight: $md-font-medium;
+
+      &.md-text-field {
+        font-size: $md-data-table-header-font-size;
+      }
+    }
+
     &__blocked-field {
       height: $md-data-table-column-height - $md-data-table-border-size;
+
+      &.md-edit-dialog__blocked-field {
+        padding-bottom: 0;
+        padding-top: 0;
+      }
 
       .md-text-field-icon-container {
         align-items: center;
@@ -488,49 +506,105 @@ $md-data-table-contextual-fallback-color: null !default;
       bottom: 0;
     }
 
-    .md-table-column--header {
-      padding-top: $md-data-table-header-height / 2 - $md-data-table-header-font-size / 2;
+    &--flex {
+      align-items: center;
+      display: flex;
+
+      &-right {
+        justify-content: flex-end;
+      }
     }
 
-    .md-table-column--data {
-      padding-top: $md-data-table-column-height / 2 - $md-data-table-content-font-size / 2;
-    }
-  }
+    .md-table-checkbox {
+      &--header {
+        height: $md-data-table-header-height;
+      }
 
-  .md-table-checkbox--fixed {
-    padding-top: 10px;
+      &--footer {
+        height: $md-data-table-column-height;
+      }
+    }
   }
 }
 
+/// This is a utility function for making a fixed table via css instead of inline styles. This one is a bit more
+/// reliable since you can provide the cell heights correctly.
 ///
 /// @example scss - Example Usage
-/// .fixed-table {
+/// .fixed-table--200-300 {
 ///   @include react-md-make-fixed-table(300px);
 ///
 ///   width: 200px;
 /// }
 ///
+/// .fixed-table__footless--200-300 {
+///   @include react-md-make-fixed-table(300px, $md-data-table-header-height, null);
+/// }
 ///
-/// @param {Number} height - The height to use for the fixed table.
+/// .fixed-table--viewport {
+///   @include react-md-make-fixed-table(true);
+/// }
+///
+/// @example scss - Example Usage CSS Output
+/// .fixed-table--200-300 {
+///   width: 200px;
+/// }
+///
+/// .fixed-table--200-300 .md-data-table__scroll-wrapper {
+///   max-height: 196px;
+/// }
+///
+/// .fixed-table__footless--200-300 .md-data-table__scroll-wrapper {
+///   max-height: 244px;
+/// }
+///
+/// .fixed-table--viewport .md-data-table__scroll-wrapper {
+///   max-height: calc(100vh - 104px);
+/// }
+///
+///
+/// @param {Number | Boolean} height - The height to use for the fixed table.
 /// @param {Number} header-height [$md-data-table-header-height] - The height for the table's header. If this is `null`,
 ///     this table should *not* have a fixed header.
 /// @param {Number} footer-height [$md-data-table-column-height] - The height for the table's footer. If this is `null`,
 ///     the table should *not* have a fixed footer.
-@mixin react-md-make-fixed-table($height, $header-height: $md-data-table-header-height, $footer-height: $md-data-table-column-height) {
-  $wrapper-height: $height;
-  @if $md-data-table-fixed-include-headers and $header-height != null {
-    $wrapper-height: $wrapper-height - $header-height;
-  }
-
-  @if $md-data-table-fixed-include-footers and $footer-height != null {
-    $wrapper-height: $wrapper-height - $footer-height;
-  }
-
-  @if ($wrapper-height != $height) {
+/// @param {Number} toolbar-height [null] - An optinal height of the toolbar to exclude when making the max-height of the
+///     table.
+@mixin react-md-make-fixed-table($height, $header-height: $md-data-table-header-height, $footer-height: $md-data-table-column-height, $toolbar-height: null) {
+  @if $height == true {
     .md-data-table__scroll-wrapper {
-      height: $height - $header-height;
+      $wrapper-height: 0;
+      @if $md-data-table-fixed-include-headers and $header-height != null {
+        $wrapper-height: $wrapper-height + $header-height;
+      }
+
+      @if $md-data-table-fixed-include-footers and $footer-height != null {
+        $wrapper-height: $wrapper-height + $footer-height;
+      }
+
+      @if $toolbar-height != null {
+        $wrapper-height: $wrapper-height + $toolbar-height;
+      }
+
+      max-height: calc(100vh - #{$wrapper-height});
+    }
+  } @else {
+    $wrapper-height: $height;
+    @if $md-data-table-fixed-include-headers and $header-height != null {
+      $wrapper-height: $wrapper-height - $header-height;
+    }
+
+    @if $md-data-table-fixed-include-footers and $footer-height != null {
+      $wrapper-height: $wrapper-height - $footer-height;
+    }
+
+    @if ($wrapper-height != $height) {
+      .md-data-table__scroll-wrapper {
+        max-height: $wrapper-height;
+      }
     }
   }
+
 }
 
 /// Creates the styles for the `TableCardHeader` component only. The contextual


### PR DESCRIPTION
Whew. Only took me about 5 months after the initial pull request to finish it.... Anyways.

### Video
Since I don't really know how to make great gifs, here's a video of it in action: https://youtu.be/sNjizErt_is

### Description
DataTables now have the ability to have a fixed header and footer. This can be enabled by providing a `fixedHeader` and/or `fixedFooter` to fix each part. Once you have a fixed table, you just need to set an optional width and a required height via the `react-md-make-fixed-table` mixin or the `fixedWidth`/`fixedHeight` props.

##### react-md-make-fixed-table
```scss
@mixin react-md-make-fixed-table($height, $header-height, $footer-height, $additional-heights)
```

This mixin is my preferred method of creating a fixed table. A fixed table is created by making a custom class name and providing some height (or boolean if it should be related to view-height) for your table. Examples:

```scss
.fixed-table--200-300 {
  @include react-md-make-fixed-table(300px);

  width: 200px;
}

.fixed-table--viewport {
  @include react-md-make-fixed-table(true);
}
```

This first class would make a table with a width of `200px` and a scroll height of `196px`. This scroll height is the provided height minus the table header's and table footer's heights. If your table does not have a fixed header or a fixed footer, you can disable this by either providing `null` for that parameter or disabling one of the variables: `md-data-table-fixed-include-header`, `md-data-table-fixed-include-footer`

The second class would make a fixed table relative to the viewport. It's ending height would end up being `calc(100vh - 104px)` (`56px` for header and `48px` for footer).

##### fixedWidth/fixedHeight props
The same positioning of a fixed table can be enabled via props if this is more preferred. It will update the styles for the respective wrappers to make the scroll content as desired. When calculating the overall height of the container, it will do additional calculations based on the `headerHeight`, `footerHeight`, `fixedHeader`, and `fixedFooter` props.


### To be improved / what's next
I think this solution might be the most accessible out of all the other ways I have seen it done, but I still need to check to see if I need to update some aria attributes for screen readers. It does seem like the tab index messes up a few times as well with this.

I would really like if I could get the scrollbar to position to the right of the wrapper instead of at the end of the table, but it seems impossible right now.

If the window ends up scrolling instead of your scroll container, any select fields/edit dialogs will no longer be positioned 100% correctly. I think this is ok for now since the fixed interactable table seems like its main use-case would be an entire page layout and you can set the height relative to the viewport with the `react-md-make-fixed-table` mixin.

Number columns do not really position correctly if fixed, so you will need to manually set the width of them if you want them to float to the right.

Finally, I need to finish making additional column wrappers for the `MenuButton` and `DropdownMenu` components so that they position correctly in a table.

### Hopeful changes down the road
Once [position: sticky](https://developer.mozilla.org/en-US/docs/Web/CSS/position#Sticky_positioning) gets full support, all this hacking could hopefully be undone.