### PR TITLE
Fixed DatePicker issue #315.

### DIFF
--- a/src/js/utils/DateUtils/addDate.js
+++ b/src/js/utils/DateUtils/addDate.js
@@ -14,6 +14,7 @@ export default function addDate(sourceDate, amt, part) {
     case 'D':
       return new Date(date.setDate(date.getDate() + amt));
     case 'M':
+      date.setDate(1);
       return new Date(date.setMonth(date.getMonth() + amt));
     case 'Y':
       return new Date(date.setFullYear(date.getFullYear() + amt));


### PR DESCRIPTION
Hello,

This is a PR for issue #315.

The simplest solution I found to fix this issue is to roll over the date to the first day of the month. 
What do you think? 

Fix 2 behaviors when current day is bigger than the next/previous month last day:
- skipping next month
- need to click twice on previous
