### PR TITLE
Bugfix/form inputs

### DIFF
--- a/src/js/Helpers/AccessibleFakeButton.js
+++ b/src/js/Helpers/AccessibleFakeButton.js
@@ -2,7 +2,8 @@ import React, { PureComponent, Children } from 'react';
 import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
 import cn from 'classnames';
-import { TAB, ENTER, SPACE } from '../constants/keyCodes';
+import { TAB } from '../constants/keyCodes';
+import handleKeyboardAccessibility from '../utils/EventUtils/handleKeyboardAccessibility';
 
 /**
  * The `AccessibleFakeButton` is a generic component that can be used to render
@@ -90,12 +91,28 @@ export default class AccessibleFakeButton extends PureComponent {
      * @access private
      */
     ink: PropTypes.node,
+
+    /**
+     * Boolean if the spacebar should be used to trigger the click event. This _should_ be `true`
+     * is almost all cases.
+     */
+    listenToSpace: PropTypes.bool,
+
+    /**
+     * Boolean if the enter key should be used to trigger the click event. This _should_ be `true`
+     * in most cases. By default, the param will be ignored if the `role` attribute is for a `checkbox`
+     * or `radio`. When it is a checkbox or radio, it will attempt to submit the form on the enter
+     * keypress instead like the native elements.
+     */
+    listenToEnter: PropTypes.bool,
   };
 
   static defaultProps = {
     component: 'div',
     tabIndex: 0,
     role: 'button',
+    listenToEnter: true,
+    listenToSpace: true,
   };
 
   constructor(props) {
@@ -147,24 +164,16 @@ export default class AccessibleFakeButton extends PureComponent {
   }
 
   _handleKeyDown(e) {
-    if (this.props.disabled) {
+    const { disabled, onKeyDown, listenToEnter, listenToSpace } = this.props;
+    if (disabled) {
       return;
     }
 
-    if (this.props.onKeyDown) {
-      this.props.onKeyDown(e);
+    if (onKeyDown) {
+      onKeyDown(e);
     }
 
-    const key = e.which || e.keyCode;
-    const space = key === SPACE;
-    if (space) {
-      // prevent the page from scrolling
-      e.preventDefault();
-    }
-
-    if (key === ENTER || space) {
-      this._handleClick(e);
-    }
+    handleKeyboardAccessibility(e, this._handleClick, listenToEnter, listenToSpace);
   }
 
   _handleKeyUp(e) {
@@ -208,6 +217,8 @@ export default class AccessibleFakeButton extends PureComponent {
     delete props.onKeyUp;
     delete props.onKeyDown;
     delete props.onTabFocus;
+    delete props.listenToEnter;
+    delete props.listenToSpace;
 
     let childElements = children;
     if (ink) {

--- a/src/js/Helpers/__tests__/AccessibleFakeButton.js
+++ b/src/js/Helpers/__tests__/AccessibleFakeButton.js
@@ -1,5 +1,7 @@
 /* eslint-env jest */
 jest.unmock('../AccessibleFakeButton');
+jest.unmock('../../utils/EventUtils/handleKeyboardAccessibility');
+
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 

--- a/src/js/Inks/InkContainer.js
+++ b/src/js/Inks/InkContainer.js
@@ -5,9 +5,10 @@ import TransitionGroup from 'react-transition-group/TransitionGroup';
 import cn from 'classnames';
 
 import { ENTER, SPACE } from '../constants/keyCodes';
+import calcPageOffset from '../utils/calcPageOffset';
+import isFormPartRole from '../utils/isFormPartRole';
 import isValidClick from '../utils/EventUtils/isValidClick';
 import captureNextEvent from '../utils/EventUtils/captureNextEvent';
-import calcPageOffset from '../utils/calcPageOffset';
 import calculateHypotenuse from '../utils/NumberUtils/calculateHypotenuse';
 
 import Ink from './Ink';
@@ -282,7 +283,10 @@ export default class InkContainer extends PureComponent {
 
   _handleKeyDown(e) {
     const key = e.which || e.keyCode;
-    if (key === ENTER || key === SPACE) {
+    const enter = key === ENTER;
+    const space = key === SPACE;
+    // Don't trigger ink when enter key is pressed and the target has an input inside of it (SelectField)
+    if (space || (enter && !isFormPartRole(e.target) && !e.target.querySelector('input'))) {
       this._clicked = true;
       this.createInk();
       this._maybeDelayClick();

--- a/src/js/Pickers/DatePickerContainer.js
+++ b/src/js/Pickers/DatePickerContainer.js
@@ -5,9 +5,10 @@ import cn from 'classnames';
 import isRequiredForA11y from 'react-prop-types/lib/isRequiredForA11y';
 import deprecated from 'react-prop-types/lib/deprecated';
 
-import { ESC, ENTER } from '../constants/keyCodes';
+import { ESC, TAB } from '../constants/keyCodes';
 import getField from '../utils/getField';
 import handleWindowClickListeners from '../utils/EventUtils/handleWindowClickListeners';
+import handleKeyboardAccessibility from '../utils/EventUtils/handleKeyboardAccessibility';
 import controlled from '../utils/PropTypes/controlled';
 import isDateEqual from '../utils/DateUtils/isDateEqual';
 import addDate from '../utils/DateUtils/addDate';
@@ -390,6 +391,12 @@ export default class DatePickerContainer extends PureComponent {
     renderNode: PropTypes.object,
 
     /**
+     * Boolean if the DatePicker should be read only. This will prevent the user from opening the picker
+     * and only display the current date in the text field.
+     */
+    readOnly: PropTypes.bool,
+
+    /**
      * Boolean if the dialog should be rendered as the last child of the `renderNode` or `body` instead
      * of the first.
      */
@@ -560,7 +567,7 @@ export default class DatePickerContainer extends PureComponent {
   }
 
   _toggleOpen(e) {
-    if (this.props.disabled) {
+    if (this.props.disabled || this.props.readOnly) {
       return;
     }
 
@@ -578,8 +585,10 @@ export default class DatePickerContainer extends PureComponent {
   }
 
   _handleKeyDown(e) {
-    if ((e.which || e.keyCode) === ENTER) {
-      this._toggleOpen(e);
+    handleKeyboardAccessibility(e, this._toggleOpen, true, true);
+
+    if ((e.which || e.keyCode) === TAB && this.state.active) {
+      this.setState({ active: false });
     }
   }
 
@@ -778,6 +787,7 @@ export default class DatePickerContainer extends PureComponent {
     delete props.value;
     delete props.onChange;
     delete props.visible;
+    delete props.readOnly;
     delete props.onVisibilityToggle;
     delete props.defaultValue;
     delete props.defaultVisible;

--- a/src/js/Pickers/TimePickerContainer.js
+++ b/src/js/Pickers/TimePickerContainer.js
@@ -5,9 +5,10 @@ import cn from 'classnames';
 import isRequiredForA11y from 'react-prop-types/lib/isRequiredForA11y';
 import deprecated from 'react-prop-types/lib/deprecated';
 
-import { ESC, ENTER } from '../constants/keyCodes';
+import { ESC, TAB } from '../constants/keyCodes';
 import getField from '../utils/getField';
 import handleWindowClickListeners from '../utils/EventUtils/handleWindowClickListeners';
+import handleKeyboardAccessibility from '../utils/EventUtils/handleKeyboardAccessibility';
 import controlled from '../utils/PropTypes/controlled';
 import DateTimeFormat from '../utils/DateUtils/DateTimeFormat';
 import formatTime from '../utils/DateUtils/formatTime';
@@ -311,6 +312,13 @@ export default class TimePickerContainer extends PureComponent {
      * of the first.
      */
     lastChild: PropTypes.bool,
+
+    /**
+     * Boolean if the TimePicker should be read only. This will prevent the user from opening the picker
+     * and only display the current date in the text field.
+     */
+    readOnly: PropTypes.bool,
+
     isOpen: deprecated(PropTypes.bool, 'Use `visible` instead'),
     initiallyOpen: deprecated(PropTypes.bool, 'Use `defaultVisible` instead'),
     initialTimeMode: deprecated(PropTypes.oneOf(['hour', 'minute']), 'Use `defaultTimeMode` instead'),
@@ -431,7 +439,7 @@ export default class TimePickerContainer extends PureComponent {
   }
 
   _toggleOpen(e) {
-    if (this.props.disabled) {
+    if (this.props.disabled || this.props.readOnly) {
       return;
     }
 
@@ -461,8 +469,10 @@ export default class TimePickerContainer extends PureComponent {
   }
 
   _handleKeyDown(e) {
-    if ((e.which || e.keyCode) === ENTER) {
-      this._toggleOpen(e);
+    handleKeyboardAccessibility(e, this._toggleOpen, true, true);
+
+    if ((e.which || e.keyCode) === TAB && this.state.active) {
+      this.setState({ active: false });
     }
   }
 
@@ -568,6 +578,7 @@ export default class TimePickerContainer extends PureComponent {
     delete props.value;
     delete props.onVisibilityChange;
     delete props.onChange;
+    delete props.readOnly;
     delete props.defaultValue;
     delete props.defaultVisible;
     delete props.defaultTimeMode;

--- a/src/js/SelectFields/Field.js
+++ b/src/js/SelectFields/Field.js
@@ -112,6 +112,7 @@ export default class Field extends PureComponent {
     return (
       <AccessibleFakeInkedButton
         {...props}
+        role="listbox"
         disabled={disabled}
         component={Paper}
         zDepth={below && active ? 1 : 0}

--- a/src/js/SelectFields/SelectField.js
+++ b/src/js/SelectFields/SelectField.js
@@ -5,8 +5,9 @@ import { findDOMNode } from 'react-dom';
 import deprecated from 'react-prop-types/lib/deprecated';
 import isRequiredForA11y from 'react-prop-types/lib/isRequiredForA11y';
 
-import { UP, DOWN, ESC, ENTER, TAB, ZERO, NINE, KEYPAD_ZERO, KEYPAD_NINE } from '../constants/keyCodes';
+import { UP, DOWN, ESC, ENTER, SPACE, TAB, ZERO, NINE, KEYPAD_ZERO, KEYPAD_NINE } from '../constants/keyCodes';
 import getField from '../utils/getField';
+import handleKeyboardAccessibility from '../utils/EventUtils/handleKeyboardAccessibility';
 import controlled from '../utils/PropTypes/controlled';
 import isBetween from '../utils/NumberUtils/isBetween';
 import addSuffix from '../utils/StringUtils/addSuffix';
@@ -711,10 +712,14 @@ export default class SelectField extends PureComponent {
 
     if (key === UP || key === DOWN) {
       e.preventDefault();
+
+      if (!isOpen) {
+        this._handleOpen(e);
+        return;
+      }
     }
 
-    if (!isOpen && (key === DOWN || key === UP || key === ENTER)) {
-      this._handleOpen(e);
+    if (!isOpen && handleKeyboardAccessibility(e, this._handleOpen, true, true)) {
       return;
     } else if (isOpen && (key === ESC || key === TAB)) {
       if (this._field && key === ESC) {
@@ -731,6 +736,7 @@ export default class SelectField extends PureComponent {
         this._advanceFocus(key === UP, e);
         break;
       case ENTER:
+      case SPACE:
         if (this._field) {
           this._field.focus();
         }

--- a/src/js/SelectionControls/SelectionControl.js
+++ b/src/js/SelectionControls/SelectionControl.js
@@ -179,6 +179,11 @@ export default class SelectionControl extends PureComponent {
      */
     uncheckedRadioIconClassName: PropTypes.string,
 
+    /**
+     * An optional tab index to apply to the selection control.
+     */
+    tabIndex: PropTypes.number,
+
     checkedIcon: preventDouble(deprecated(
       PropTypes.node,
       'Use the `checkedCheckboxIconChildren` and `checkedCheckboxIconClassName`  or the ' +
@@ -281,6 +286,7 @@ export default class SelectionControl extends PureComponent {
       labelBefore,
       onBlur,
       onFocus,
+      tabIndex,
       ...props
     } = this.props;
     delete props.label;
@@ -340,6 +346,7 @@ export default class SelectionControl extends PureComponent {
           })}
           role={type}
           aria-checked={checked}
+          tabIndex={tabIndex}
         >
           {this._getIcon()}
         </AccessibleFakeInkedButton>

--- a/src/js/utils/EventUtils/__tests__/handleKeyboardAccessibility.js
+++ b/src/js/utils/EventUtils/__tests__/handleKeyboardAccessibility.js
@@ -1,0 +1,69 @@
+/* eslint-env jest */
+jest.unmock('../handleKeyboardAccessibility');
+jest.unmock('../../isFormPartRole');
+
+import handleKeyboardAccessibility from '../handleKeyboardAccessibility';
+import closest from '../../closest';
+import { ENTER, SPACE } from '../../../constants/keyCodes';
+
+const preventDefault = jest.fn();
+const FAKE_BUTTON = { getAttribute: jest.fn(() => 'button') };
+
+const FAKE_RADIO = { getAttribute: jest.fn(() => 'radio') };
+
+const FAKE_CHECKBOX = { getAttribute: jest.fn(() => 'checkbox') };
+
+describe('handleKeyboardAccessibility', () => {
+  it('should trigger the onClick callback when listenToEnter is true and the enter key was pressed', () => {
+    const event = { which: ENTER, keyCode: ENTER, target: FAKE_BUTTON, preventDefault };
+    const onClick = jest.fn();
+    handleKeyboardAccessibility(event, onClick, true, true);
+    expect(onClick).toBeCalled();
+  });
+
+  it('should not trigger the onClick callback when listenToEnter is false and the enter key was pressed', () => {
+    const event = { which: ENTER, keyCode: ENTER, target: FAKE_BUTTON, preventDefault };
+    const onClick = jest.fn();
+    handleKeyboardAccessibility(event, onClick, false, true);
+    expect(onClick).not.toBeCalled();
+  });
+
+  it('should trigger the onClick callback when listenToEnter is true and the space key was pressed', () => {
+    const event = { which: SPACE, keyCode: SPACE, target: FAKE_BUTTON, preventDefault };
+    const onClick = jest.fn();
+    handleKeyboardAccessibility(event, onClick, true, true);
+    expect(onClick).toBeCalled();
+  });
+
+  it('should not trigger the onClick callback when listenToEnter is false and the space key was pressed', () => {
+    const event = { which: SPACE, keyCode: SPACE, target: FAKE_BUTTON, preventDefault };
+    const onClick = jest.fn();
+    handleKeyboardAccessibility(event, onClick, true, false);
+    expect(onClick).not.toBeCalled();
+  });
+
+  it('should not trigger the onClick callback if the role is a form element and the enter key was pressed', () => {
+    const onClick = jest.fn();
+    const event = { which: ENTER, keyCode: ENTER, target: FAKE_CHECKBOX, preventDefault };
+    const event2 = { which: ENTER, keyCode: ENTER, target: FAKE_RADIO, preventDefault };
+
+    handleKeyboardAccessibility(event, onClick, true, true);
+    handleKeyboardAccessibility(event2, onClick, true, true);
+    expect(onClick).not.toBeCalled();
+  });
+
+  it('should attempt to submit a form when the enter key is pressed and it is a form role', () => {
+    const submit = { click: jest.fn() };
+    const form = { querySelector: jest.fn(() => submit) };
+    closest.mockImplementationOnce(() => form);
+
+    const onClick = jest.fn();
+    const event = { which: ENTER, keyCode: ENTER, target: FAKE_CHECKBOX, preventDefault };
+    handleKeyboardAccessibility(event, onClick, true, true);
+
+    expect(onClick).not.toBeCalled();
+    expect(closest).toBeCalledWith(event.target, 'form');
+    expect(form.querySelector).toBeCalledWith('*[type="submit"]');
+    expect(submit.click).toBeCalled();
+  });
+});

--- a/src/js/utils/EventUtils/handleKeyboardAccessibility.js
+++ b/src/js/utils/EventUtils/handleKeyboardAccessibility.js
@@ -21,8 +21,9 @@ import isFormPartRole from '../isFormPartRole';
  *      is for a form role.
  * @param {boolean=true} listenToSpace - boolean if the space key should be used to trigger the
  *      click event.
+ * @return {Boolean} true if the enter or space keys were pressed while their listener is also active.
  */
-export default function handleKeyboardAccesibility(e, onClick, listenToEnter = true, listenToSpace = true) {
+export default function handleKeyboardAccessibility(e, onClick, listenToEnter = true, listenToSpace = true) {
   const key = e.which || e.keyCode;
   const space = listenToSpace && key === SPACE;
   const enter = key === ENTER;
@@ -39,10 +40,14 @@ export default function handleKeyboardAccesibility(e, onClick, listenToEnter = t
       submit.click();
     }
 
-    return;
+    return true;
   }
 
   if ((enter && listenToEnter) || space) {
     onClick(e);
+
+    return true;
   }
+
+  return false;
 }

--- a/src/js/utils/EventUtils/handleKeyboardAccessibility.js
+++ b/src/js/utils/EventUtils/handleKeyboardAccessibility.js
@@ -1,0 +1,48 @@
+import { SPACE, ENTER } from '../../constants/keyCodes';
+import closest from '../closest';
+import isFormPartRole from '../isFormPartRole';
+
+/**
+ * A utility function for adding keyboard accessibility to elements that are not a natively
+ * clickable (div, span, etc). When the space or enter key is pressed while focusing the
+ * element, different flows will happen.
+ *
+ * - space - The click event will be triggered and the default page scrolling behavior of the
+ *      spacebar will be prevented
+ * - enter - If the element has a form role ('checkbox' or 'radio'), the click event will not
+ *      be triggered. Instead, it will find out if the element is inside a form. If it is, it
+ *      will emulate the default behavior of attempting to submit the form. If the element does
+ *      not have a form role, the click event will be triggered.
+ *
+ * @param {Event} e - the keydown event
+ * @param {function} onClick - the on click event to be triggered if space or enter was pressed
+ * @param {boolean=true} listenToEnter - boolean if the enter key should be used to trigger the
+ *      the click event. Even if this is true, the click event will not be triggered if the role
+ *      is for a form role.
+ * @param {boolean=true} listenToSpace - boolean if the space key should be used to trigger the
+ *      click event.
+ */
+export default function handleKeyboardAccesibility(e, onClick, listenToEnter = true, listenToSpace = true) {
+  const key = e.which || e.keyCode;
+  const space = listenToSpace && key === SPACE;
+  const enter = key === ENTER;
+
+  if (space) {
+    // Stop page scrolling
+    e.preventDefault();
+  }
+
+  if (enter && isFormPartRole(e.target)) {
+    const form = closest(e.target, 'form');
+    const submit = form ? form.querySelector('*[type="submit"]') : null;
+    if (submit) {
+      submit.click();
+    }
+
+    return;
+  }
+
+  if ((enter && listenToEnter) || space) {
+    onClick(e);
+  }
+}

--- a/src/js/utils/NumberUtils/__tests__/minMaxLoop.js
+++ b/src/js/utils/NumberUtils/__tests__/minMaxLoop.js
@@ -1,0 +1,32 @@
+/* eslint-env jest */
+jest.unmock('../minMaxLoop');
+
+import minMaxLoop from '../minMaxLoop';
+
+describe('minMaxLoop', () => {
+  it('should increment the current number by 1 when increment is true', () => {
+    const current = 0;
+    const expected = 1;
+    expect(minMaxLoop(current, 0, 5, true)).toBe(expected);
+  });
+
+  it('should decrement the current number by 1 when increment is false', () => {
+    const current = 1;
+    const expected = 0;
+    expect(minMaxLoop(current, 0, 5, false)).toBe(expected);
+  });
+
+  it('should return the max number when decrementing at the min value', () => {
+    const current = 0;
+    const min = 0;
+    const max = 5;
+    expect(minMaxLoop(current, min, max, false)).toBe(max);
+  });
+
+  it('should return the min number when incrementing at the max value', () => {
+    const current = 5;
+    const min = 0;
+    const max = 5;
+    expect(minMaxLoop(current, min, max, true)).toBe(min);
+  });
+});

--- a/src/js/utils/NumberUtils/minMaxLoop.js
+++ b/src/js/utils/NumberUtils/minMaxLoop.js
@@ -1,0 +1,22 @@
+/**
+ * Keeps a number within the min and max values. When the number becomes less
+ * than the min, it will loop around and be the max value. When the number is
+ * greater than the max, it will loop around and be the min value.
+ *
+ * @param {Number} current - the current number
+ * @param {Number} min - the minimum number allowed
+ * @param {Number} max - the maximum number allowed
+ * @param {Boolean} increment - boolean if the value should be incremented or decremented by
+ *    1.
+ * @return {Number} the next number
+ */
+export default function minMaxLoop(current, min, max, increment = true) {
+  let next = current + (increment ? 1 : -1);
+  if (max < next) {
+    next = min;
+  } else if (next < min) {
+    next = max;
+  }
+
+  return next;
+}

--- a/src/js/utils/__tests__/isFormPartRole.js
+++ b/src/js/utils/__tests__/isFormPartRole.js
@@ -19,4 +19,14 @@ describe('isFormPartRole', () => {
     const el = { getAttribute: () => 'radio' };
     expect(isFormPartRole(el)).toBe(true);
   });
+
+  it('should return true if the nodeName is INPUT', () => {
+    const el = { nodeName: 'INPUT', getAttribute: jest.fn() };
+    expect(isFormPartRole(el)).toBe(true);
+  });
+
+  it('should return false if the nodeName is DIV', () => {
+    const el = { nodeName: 'DIV', getAttribute: jest.fn() };
+    expect(isFormPartRole(el)).toBe(false);
+  });
 });

--- a/src/js/utils/__tests__/isFormPartRole.js
+++ b/src/js/utils/__tests__/isFormPartRole.js
@@ -1,0 +1,22 @@
+/* eslint-env jest */
+jest.unmock('../isFormPartRole');
+
+import isFormPartRole from '../isFormPartRole';
+
+describe('isFormPartRole', () => {
+  it('should return false if the el is false-ish', () => {
+    expect(isFormPartRole()).toBe(false);
+    expect(isFormPartRole(undefined)).toBe(false);
+    expect(isFormPartRole(null)).toBe(false);
+  });
+
+  it('should return true if the role attribute is checkbox', () => {
+    const el = { getAttribute: () => 'checkbox' };
+    expect(isFormPartRole(el)).toBe(true);
+  });
+
+  it('should return true if the role attribute is radio', () => {
+    const el = { getAttribute: () => 'radio' };
+    expect(isFormPartRole(el)).toBe(true);
+  });
+});

--- a/src/js/utils/closest.js
+++ b/src/js/utils/closest.js
@@ -1,0 +1,26 @@
+/**
+ * A _very_ primitive polyfill for the Element.closest function. If this is a browser that doesn't
+ * support it (IE, Edge, etc), it will just keep searching the parent elements until the nodeName
+ * matches the provided type.
+ *
+ * @param {Element} el - the html element to find a closest node type for
+ * @param {String} type - the html element type to find.
+ * @return {Element} the found element or null.
+ */
+export default function closest(el, type) {
+  if (typeof el.closest === 'function') {
+    return el.closest(type);
+  }
+
+  const nodeType = type.toUpperCase();
+  let node = el.parentElement;
+  while (node && node.parentElement) {
+    if (node.nodeName === nodeType) {
+      return node;
+    }
+
+    node = node.parentElement;
+  }
+
+  return null;
+}

--- a/src/js/utils/isFormPartRole.js
+++ b/src/js/utils/isFormPartRole.js
@@ -1,0 +1,16 @@
+/**
+ * A simple utility function to determine if an element has a role that should
+ * be used as a form part. This is mostly used for changing the behavior of keyboard
+ * events.
+ *
+ * @param {HTMLElement} el - the element to check.
+ * @return {boolean} true if the element is considered an element part of a form.
+ */
+export default function isFormPartRole(el) {
+  if (!el) {
+    return false;
+  }
+
+  const role = el.getAttribute('role');
+  return role === 'checkbox' || role === 'radio';
+}

--- a/src/js/utils/isFormPartRole.js
+++ b/src/js/utils/isFormPartRole.js
@@ -7,6 +7,7 @@
  * - checkbox
  * - radio
  * - listbox
+ * - input
  *
  * @param {HTMLElement} el - the element to check.
  * @return {boolean} true if the element is considered an element part of a form.
@@ -14,6 +15,8 @@
 export default function isFormPartRole(el) {
   if (!el) {
     return false;
+  } else if (el.nodeName === 'INPUT') {
+    return true;
   }
 
   const role = el.getAttribute('role');

--- a/src/js/utils/isFormPartRole.js
+++ b/src/js/utils/isFormPartRole.js
@@ -3,6 +3,11 @@
  * be used as a form part. This is mostly used for changing the behavior of keyboard
  * events.
  *
+ * A form part role is one of the following:
+ * - checkbox
+ * - radio
+ * - listbox
+ *
  * @param {HTMLElement} el - the element to check.
  * @return {boolean} true if the element is considered an element part of a form.
  */
@@ -12,5 +17,5 @@ export default function isFormPartRole(el) {
   }
 
   const role = el.getAttribute('role');
-  return role === 'checkbox' || role === 'radio';
+  return role === 'checkbox' || role === 'radio' || role === 'listbox';
 }


### PR DESCRIPTION
### Updated Picker Leopard Usage
Pickers will now only be openable with the spacebar key like other form
inputs. Pressing enter will just attempt to submit a form instead. In
addition, fixed the readOnly problem for pickers.

### Fixed Leopard Accessibility for SelectField
The select field now behaves like the native select field. The options
will only be toggleable with the space key. Pressing enter will attempt
to submit a form instead. The list items can still be selected with the
enter key.

### Fixed Radio Leopard Accessibility
Fixed the Radio buttons so that it behaves like the native radio. Only
the currently checked radio will be tab-focusable. The suer can then
select a different radio by pressing the up, right, down, or left arrow
keys to select the next value.

### Updated Accessibility for Form Controls
It looks like I haven't played around with native form controls enough..
The AccessibleFakeButton will now correctly attempt to submit a form
when the enter key is pressed instead of triggering the click event.
This means that Checkbox, Radio, and Switch will now *not* be
toggle-able with the enter key. It will now require the space key.

This should close #364 and #363 