### PR TITLE
Detect TextArea resizes other than browser window resize

### DIFF
--- a/src/js/TextFields/InputField.js
+++ b/src/js/TextFields/InputField.js
@@ -27,6 +27,7 @@ export default class InputField extends PureComponent {
     passwordVisible: PropTypes.bool,
     inlineIndicator: PropTypes.bool,
     onHeightChange: PropTypes.func,
+    setContainerRef: PropTypes.func,
   };
 
   getField = () => { // eslint-disable-line arrow-body-style
@@ -68,6 +69,7 @@ export default class InputField extends PureComponent {
       inlineIndicator,
       maxRows,
       onHeightChange,
+      setContainerRef,
       ...props
     } = this.props;
 
@@ -80,6 +82,7 @@ export default class InputField extends PureComponent {
       props.block = block;
       props.maxRows = maxRows;
       props.onHeightChange = onHeightChange;
+      props.setContainerRef = setContainerRef;
     }
 
     return createElement(Component, {


### PR DESCRIPTION
This commit fixes some problems with spacing of multiline text fields.

### Problem 1: multiline `TextFields` do not recalculate dimensions upon element resize

In some cases react-md styles load after the `TextArea` has calculated its height.  In this case the height may be based upon the user agent defaults, which can result in very narrow and tall `textarea`s when there is an initial value.

Here is an example of a textarea rendered by a `TextArea`.  This page has a breakpoint in `TextArea.__syncHeightWithMask`.  You can see that the `textarea` that is being measured by this method has no styles applied, and is very narrow and tall.  (The measured property is `scrollHeight`, which is the whole size of the element, including what is not visible.)

![screen shot 2017-06-23 at 16 00 51 edt](https://user-images.githubusercontent.com/78054/27499144-6bbc1ba0-5830-11e7-955b-a5f9a19872a9.png)

This results in an initial rendering of the `TextArea` that is too tall, as shown in the picture below:

![screen shot 2017-06-23 at 16 02 41 edt](https://user-images.githubusercontent.com/78054/27499206-c912a260-5830-11e7-89e6-794c4d9c191c.png)

The fix for this is to use `resize-observer-polyfill` as the trigger for the methods that update the dimensions of a multiline `TextField` instead of the `window`'s `resize` event.

### Issue 2: `TextField._updateMultilineHeight` receives incorrect arguments and so does not update properly on resize

The calls to `TextField._updateMultilineHeight` that are `resize` handlers receive an event as their first argument, preventing this method from receiving the default argument of `this.props`.  `this._isMultiline(event)` will be false, causing the method to return and not to update the `_additionalHeight`.  Combined with the issue above of reading `_additionalHeight` initially from an unstyled element, this results in too small of `_additionalHeight`, as you can see in the image below where the input underneath the multiline `TextField` is overlapping because the `TextArea` has too small of a `height`.

![screen shot 2017-06-23 at 16 19 14 edt](https://user-images.githubusercontent.com/78054/27499873-c5da71b0-5833-11e7-9021-6c15eac093ca.png)

(The label "Citation" from the lower input is overlapping the divider of the multiline `TextField` above it.

### Additional change: replace `findDOMNode` with `ref` property.

To determine the extra `top-margin` on its contents, `TextField._updateMultilineHeight` needs to inspect the `TextArea`'s container.  Right now it is looking at `findDOMNode(this._field)`.  [It appears that `findDOMNode` is, or will be, deprecated](https://github.com/yannickcr/eslint-plugin-react/issues/678#issue-165177220), so this commit instead adds a ref property on `TextArea` (`setContainerRef`) so that the `TextField` can explicitly obtain the element.

