### PR TITLE
Fix React warning on Tabs with alignToKeyline

### DIFF
--- a/src/js/Tabs/Tabs.js
+++ b/src/js/Tabs/Tabs.js
@@ -444,6 +444,7 @@ export default class Tabs extends PureComponent {
     delete props.defaultMedia;
     delete props.desktopMinWidth;
     delete props.onTabChange;
+    delete props.alignToKeyline;
 
     const activeTabIndex = getField(this.props, this.state, 'activeTabIndex');
 


### PR DESCRIPTION
Setting the alignToKeyline prop on the Tabs component triggers a console warning from React. This keeps that from happening. See issue #440.