### PR TITLE
Bugfix/resize observer

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "react-motion": "^0.5.0",
     "react-prop-types": "^0.4.0",
     "react-swipeable-views": "^0.12.1",
-    "react-transition-group": "^1.1.3"
+    "react-transition-group": "^1.1.3",
+    "resize-observer-polyfill": "^1.4.2"
   },
   "peerDependencies": {
     "react": ">= 15.3.0",
@@ -92,7 +93,9 @@
     "setupFiles": [
       "<rootDir>/src/beforeTest.js"
     ],
-    "testPathDirs": ["<rootDir>/src/"],
+    "testPathDirs": [
+      "<rootDir>/src/"
+    ],
     "unmockedModulePathPatterns": [
       "<rootDir>/node_modules/enzyme",
       "<rootDir>/node_modules/classnames",

--- a/src/js/ExpansionPanels/ExpansionPanel.js
+++ b/src/js/ExpansionPanels/ExpansionPanel.js
@@ -120,6 +120,15 @@ export default class ExpansionPanel extends PureComponent {
     columnWidths: PropTypes.arrayOf(PropTypes.number).isRequired,
 
     /**
+     * Boolean if the panel has too much content so that it overflowns. This is injected
+     * and managed by the `ExpansionList` component. Do not set yourself.
+     *
+     * When this is active, it will truncate all columns except for the main label and the
+     * toggle icon.
+     */
+    overflown: PropTypes.bool,
+
+    /**
      * A function to call when the expansion panel's expanded state is toggled.
      * The callback for this function will include the new expanded state.
      *
@@ -340,6 +349,7 @@ export default class ExpansionPanel extends PureComponent {
       contentStyle,
       contentClassName,
       tabIndex,
+      overflown,
       ...props
     } = this.props;
 
@@ -355,7 +365,12 @@ export default class ExpansionPanel extends PureComponent {
     const expanded = this._isExpanded(this.props, this.state);
 
     let columns = Children.map(expanded && expandedSecondaryLabel || secondaryLabel, (panelLabel, i) => (
-      <div className="md-panel-column md-text" style={{ minWidth: columnWidths[i + 1] }}>
+      <div
+        style={{ [`${overflown ? 'width' : 'minWidth'}`]: columnWidths[i + 1] }}
+        className={cn('md-panel-column md-text', {
+          'md-panel-column--overflown': overflown,
+        })}
+      >
         {panelLabel}
       </div>
     ));
@@ -388,7 +403,11 @@ export default class ExpansionPanel extends PureComponent {
           tabIndex={tabIndex}
         >
           {columns}
-          <Collapser flipped={expanded} iconClassName={expandIconClassName} className="md-cell--right">
+          <Collapser
+            flipped={expanded}
+            iconClassName={expandIconClassName}
+            className="md-cell--right md-expansion-panel__collapser"
+          >
             {expandIconChildren}
           </Collapser>
         </AccessibleFakeButton>

--- a/src/js/Helpers/ResizeObserver.js
+++ b/src/js/Helpers/ResizeObserver.js
@@ -1,0 +1,151 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import ResizeObserverAPI from 'resize-observer-polyfill';
+
+/**
+ * The `ResizeObserver` component is a component hook for the
+ * [ResizeObserver](http://rawgit.com/WICG/ResizeObserver/master/index.html)
+ * using the [resize-observer-polyfill](https://github.com/que-etc/resize-observer-polyfill)
+ * for browsers that don't support it yet.
+ *
+ * This component displays an empty `span` with `aria-hidden` to allow access to the DOM. By
+ * default it will attempt to watch changes on its parent component, but it can be configured
+ * to watch any element by using the `target` prop.
+ */
+export default class ResizeObserver extends PureComponent {
+  static propTypes = {
+    /**
+     * Boolean if the height should be watched for the resize target.
+     */
+    watchHeight: PropTypes.bool,
+
+    /**
+     * Boolean if the width should be watched for the resize target.
+     */
+    watchWidth: PropTypes.bool,
+
+    /**
+     * An optional target that should be used for detecting resize events. This can either
+     * be a HTMLDOMNode or a string to use with `document.getElementById` or `document.querySelector`.
+     *
+     * If this prop is not provided and not null, it will default to the parent node of this component.
+     * If the provided `target={null}`, the observer will not begin until the `target` is `undefined` or
+     * it has been correctly passed a target string or object.
+     */
+    target: PropTypes.oneOfType([
+      PropTypes.object,
+      PropTypes.string,
+    ]),
+
+    /**
+     * The component to be rendered as. This should normally just be the default `span`, but there are cases
+     * where the component should be switched to something else for valid html.
+     */
+    component: PropTypes.string,
+
+    /**
+     * A function to call when the height or width has been changed and that attribute is being watched.
+     * The callback will include the current height and width of the target.
+     *
+     * ```js
+     * onResize({ height: nextHeight, width: nextWidth });
+     * ```
+     */
+    onResize: PropTypes.func.isRequired,
+  };
+
+  static defaultProps = {
+    watchHeight: false,
+    watchWidth: false,
+    component: 'span',
+  };
+
+  componentWillReceiveProps(nextProps) {
+    const { target } = this.props;
+    const nextTarget = nextProps.target;
+    if (target === nextTarget) {
+      return;
+    } else if (nextTarget) {
+      if (this._target) {
+        this._observer.unobserve(this._target);
+      }
+      this._target = this._getTarget(this._container, nextTarget);
+      this._observer.observe(this._target);
+    }
+  }
+
+  _container = null;
+  _target = null;
+  _observer = null;
+  _height = null;
+  _width = null;
+
+  _getTarget(container, target) {
+    if (target === null || (target && typeof target !== 'string')) {
+      return target;
+    }
+
+    let t = null;
+    if (target) {
+      t = document.getElementById(target) || document.querySelector(target);
+    } else {
+      t = container.parentNode;
+    }
+
+    if (!t) {
+      throw new Error(
+        'An HTMLDOMNode is required as the `ResizeObserver`\'s watch target but none were provided/found. ' +
+        `Please update the target prop to find a valid node since the provided target is invalid. \`${target}\`.`
+      );
+    }
+
+    return t;
+  }
+
+  _measure = (entries) => {
+    if (!this._observer || !this._target) {
+      return;
+    }
+    const { watchHeight, watchWidth, onResize } = this.props;
+
+    for (const entry of entries) {
+      if (!entry) {
+        return;
+      }
+
+      const { height, width } = entry.contentRect;
+      if ((watchHeight && (height !== this._height)) || (watchWidth && width !== this._width)) {
+        this._height = height;
+        this._width = width;
+        onResize({ height, width });
+      }
+    }
+  };
+
+  _handleRef = (container) => {
+    if (container) {
+      this._container = container;
+      this._target = this._getTarget(container, this.props.target);
+      this._observer = new ResizeObserverAPI(this._measure);
+
+      if (this._target) {
+        this._observer.observe(this._target);
+      }
+    } else {
+      if (this._observer) {
+        this._observer.disconnect();
+      }
+
+      this._container = null;
+      this._target = null;
+      this._observer = null;
+      this._height = null;
+      this._width = null;
+    }
+  };
+
+  render() {
+    const { component: Component } = this.props;
+    return <Component ref={this._handleRef} aria-hidden />;
+  }
+}

--- a/src/js/Tabs/Tabs.js
+++ b/src/js/Tabs/Tabs.js
@@ -9,6 +9,7 @@ import getField from '../utils/getField';
 import controlled from '../utils/PropTypes/controlled';
 import TabIndicator from './TabIndicator';
 import IconSeparator from '../Helpers/IconSeparator';
+import ResizeObserver from '../Helpers/ResizeObserver';
 import FontIcon from '../FontIcons/FontIcon';
 import MenuTab from './MenuTab';
 import TabOverflowButton from './TabOverflowButton';
@@ -201,10 +202,6 @@ export default class Tabs extends PureComponent {
     this._mapToOverflowTabProps = this._mapToOverflowTabProps.bind(this);
   }
 
-  componentDidMount() {
-    window.addEventListener('resize', this._positionElements);
-  }
-
   componentWillReceiveProps(nextProps) {
     if (this.props.activeTabIndex !== nextProps.activeTabIndex) {
       this.setState({
@@ -230,10 +227,6 @@ export default class Tabs extends PureComponent {
         }, this._scrollActiveIntoView);
       }
     }
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener('resize', this._positionElements);
   }
 
   _shouldAlign(props) {
@@ -525,6 +518,7 @@ export default class Tabs extends PureComponent {
         }, className)}
         role="tablist"
       >
+        <ResizeObserver watchWidth watchHeight onResize={this._positionElements} />
         {previousControl}
         {children}
         {nextControl}

--- a/src/js/TextFields/TextField.js
+++ b/src/js/TextFields/TextField.js
@@ -405,7 +405,6 @@ export default class TextField extends PureComponent {
     this._handleBlur = this._handleBlur.bind(this);
     this._handleFocus = this._handleFocus.bind(this);
     this._handleChange = this._handleChange.bind(this);
-    this._handleHeightChange = this._handleHeightChange.bind(this);
     this._updateMultilineHeight = this._updateMultilineHeight.bind(this);
     this._togglePasswordField = this._togglePasswordField.bind(this);
     this._handleContainerClick = this._handleContainerClick.bind(this);
@@ -580,8 +579,8 @@ export default class TextField extends PureComponent {
       return;
     }
 
-    const cs = window.getComputedStyle(findDOMNode(this._field));
-    this._additionalHeight = parseInt(cs.getPropertyValue('margin-top'), 10);
+    const floating = this._node.querySelector('md-text-field--floating-margin');
+    this._additionalHeight = floating ? parseInt(window.getComputedStyle(floating).marginTop, 10) : 0;
 
     if (!block) {
       const mb = parseInt(window.getComputedStyle(this._divider).getPropertyValue('margin-bottom'), 10);
@@ -639,14 +638,8 @@ export default class TextField extends PureComponent {
     this.setState({ passwordVisible: !this.state.passwordVisible }, this.focus);
   }
 
-  _handleHeightChange(height) {
-    if (this._additionalHeight) {
-      this.setState({ height: height + this._additionalHeight });
-    }
-  }
-
   render() {
-    const { currentLength, passwordVisible, height } = this.state;
+    const { currentLength, passwordVisible } = this.state;
     const {
       id,
       type,
@@ -803,7 +796,6 @@ export default class TextField extends PureComponent {
         onFocus={this._handleFocus}
         onBlur={this._handleBlur}
         onChange={this._handleChange}
-        onHeightChange={this._handleHeightChange}
         inlineIndicator={!!inlineIndicator}
       />
     );
@@ -848,7 +840,7 @@ export default class TextField extends PureComponent {
     return (
       <div
         ref={this._setContainer}
-        style={Object.assign({}, style, { height })}
+        style={style}
         className={cn('md-text-field-container', {
           'md-inline-block': !fullWidth && !block,
           'md-full-width': block || fullWidth,

--- a/src/scss/components/_expansion-panels.scss
+++ b/src/scss/components/_expansion-panels.scss
@@ -56,6 +56,20 @@ $md-expansion-panel-expanded-height: 64px;
     }
   }
 
+  .md-panel-column {
+    &:not(:last-child) {
+      padding-right: $md-default-padding;
+    }
+
+    &--overflown {
+      flex-shrink: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      word-wrap: break-word;
+    }
+  }
+
   .md-panel-column:not(:last-child) {
     padding-right: $md-default-padding;
   }

--- a/src/scss/components/_text-fields.scss
+++ b/src/scss/components/_text-fields.scss
@@ -615,6 +615,11 @@ $md-text-field-line-height: 1.15 !default;
     .md-text-field-multiline-container {
       position: relative;
     }
+
+    .md-text-field-container--multiline {
+      display: flex;
+      flex-direction: column;
+    }
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4488,6 +4488,10 @@ require-uncached@^1.0.2:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
+resize-observer-polyfill@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.4.2.tgz#a37198e6209e888acb1532a9968e06d38b6788e5"
+
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"


### PR DESCRIPTION
This pull request introduced the `ResizeObserver` component that hooks into the `resize-observer` api. It is a fairly simple component that watches resize events on the parent node or any specified target node and triggers the `onResize` event if it has changed.

I went with this approach over the `react-measure` since it is normally rendering something depending on size while I normally run things after an update instead. Might not be the best solution, but meh :/

This should close #448, #415, and #365. This also fixed a bug where a multiline text field did not update correctly if the styles were loaded after initial render. 