### PR TITLE
fixing textfield doubleClick, tooltip container implicit any

### DIFF
--- a/src/js/TextFields/TextField.d.ts
+++ b/src/js/TextFields/TextField.d.ts
@@ -55,6 +55,7 @@ export interface TextFieldProps extends SharedTextFieldProps, Props {
   value?: number | string;
   defaultValue?: number | string;
   onChange?: (value: number | string, event: Event) => void;
+  onDoubleClick?: (event: React.MouseEvent<HTMLElement>) => void;
 
   /**
    * @deprecated

--- a/src/js/Tooltips/Tooltipped.d.ts
+++ b/src/js/Tooltips/Tooltipped.d.ts
@@ -15,8 +15,8 @@ export interface TooltippedProps extends Props {
   tooltipClassName?: string;
   enterTimeout?: number;
   leaveTimeout?: number;
-  container?: (HTMLElement) => HTMLElement;
-  target?: React.ReactElement<any> | ((HTMLElement) => React.ReactElement<any>);
+  container?: (HTMLElement: HTMLElement) => HTMLElement;
+  target?: React.ReactElement<any> | ((HTMLElement: HTMLElement) => React.ReactElement<any>);
 }
 
 declare const Tooltipped: React.ComponentClass<TooltippedProps>;


### PR DESCRIPTION
Updating the typescript .d.ts definitions to prevent tsc errors. I've updated a couple of lines. 

P.S. This is my first open source contribution, I hope I haven't committed any faux pas. 