### PR TITLE
Typescript: Make calendarTitleFormat optional

### DIFF
--- a/src/js/Pickers/index.d.ts
+++ b/src/js/Pickers/index.d.ts
@@ -62,7 +62,7 @@ export interface BasePickerProps extends SharedTextFieldProps, Props {
   firstDayOfWeek?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
   calendarDateClassName?: string;
   calendarTitleClassName?: string;
-  calendarTitleFormat: CalendarTitleFormat;
+  calendarTitleFormat?: CalendarTitleFormat;
   calendarWeekdayClassName?: string;
   calendarWeekdayFormat?: NSL;
 }


### PR DESCRIPTION
Judging from examples, this should not be required?