### PR TITLE
[TableColumn] Add colSpan and rowSpan properties to TableColumnProps interface

### DIFF
--- a/src/js/DataTables/TableColumn.d.ts
+++ b/src/js/DataTables/TableColumn.d.ts
@@ -16,6 +16,8 @@ export interface TableColumnProps extends Props, InjectedTooltipProps {
   plain?: boolean;
   scope?: 'row' | 'col';
   cellIndex?: boolean;
+  colSpan?: number;
+  rowSpan?: number;
 
   /**
    * @deprecated


### PR DESCRIPTION
Fix for #522 [TableColumn] - missing colSpan and rowSpan properties in Typescript definition 