### PR TITLE
Bugfix/select field items

### DIFF
--- a/docs/src/components/Components/SelectFields/ElementsAndDisabledItems.jsx
+++ b/docs/src/components/Components/SelectFields/ElementsAndDisabledItems.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+// import Divider from 'react-md/lib/Dividers';
+import Subheader from 'react-md/lib/Subheaders';
+import SelectField from 'react-md/lib/SelectFields';
+
+const ITEMS_WITH_DISABLED = [...new Array(15)].map((_, i) => ({
+  label: `Item ${i + 1}`,
+  value: i,
+  disabled: i === 3 || i === 4 || i === 9 || i === 13,
+}));
+
+const ITEMS_WITH_ELEMENTS = [
+  <Subheader key="subheader-1" primaryText="Items 1 - 5" className="md-divider-border md-divider-border--bottom" />,
+  'Item 1', 'Item 2', 'Item 3', 'Item 4', 'Item 5',
+  <Subheader key="subheader-2" primaryText="Items 6 - 10" className="md-divider-border md-divider-border--bottom" />,
+  'Item 6', 'Item 7', 'Item 8', 'Item 9', 'Item 10',
+  <Subheader key="subheader-3" primaryText="Items 11 - 15" className="md-divider-border md-divider-border--bottom" />,
+  'Item 11', 'Item 12', 'Item 13', 'Item 14', 'Item 15',
+];
+
+const ElementsAndDisabledItems = () => (
+  <div className="md-grid">
+    <SelectField
+      id="select-field-with-disabled"
+      label="Has Disabled Items"
+      placeholder="Select something"
+      menuItems={ITEMS_WITH_DISABLED}
+      className="md-cell md-cell--6"
+      sameWidth
+    />
+    <SelectField
+      id="select-field-with-elements"
+      label="Has Element Items"
+      placeholder="Select something"
+      menuItems={ITEMS_WITH_ELEMENTS}
+      className="md-cell md-cell--6"
+      sameWidth
+    />
+  </div>
+);
+export default ElementsAndDisabledItems;

--- a/docs/src/components/Components/SelectFields/index.jsx
+++ b/docs/src/components/Components/SelectFields/index.jsx
@@ -4,6 +4,8 @@ import ExamplesPage from 'components/ExamplesPage';
 import README from './README.md';
 import Simple from './Simple';
 import SimpleRaw from '!!raw-loader!./Simple.jsx';
+import ElementsAndDisabledItems from './ElementsAndDisabledItems';
+import ElementsAndDisabledItemsRaw from '!!raw-loader!./ElementsAndDisabledItems.jsx';
 import DefaultValuesAndControlling from './DefaultValuesAndControlling';
 import DefaultValuesAndControllingRaw from '!!raw-loader!./DefaultValuesAndControlling.jsx';
 import TextFieldStyling from './TextFieldStyling';
@@ -38,6 +40,19 @@ more information.
   `,
   code: SimpleRaw,
   children: <Simple />,
+}, {
+  title: 'Elements and Disabling Items',
+  description: `
+There are times where it is helpful to be able to render additional elements like \`Divider\`s or \`Subheader\`s
+in the selection list or disable specific items. If you want to render any additional elements, just add them to
+the \`menuItem\` list and they will be rendered. Any items that do not match the \`string\`, \`number\` or \`object\`
+shape **will be ignored** as valid selection targets for clicking, touching, or keyboard events.
+
+To disable an item, all that is required is to make sure it is an \`object\`, and add a key \`disabled: true\` to it.
+When the item is \`disabled\`, it will not be focusable or selectable.
+  `,
+  code: ElementsAndDisabledItemsRaw,
+  children: <ElementsAndDisabledItems />,
 }, {
   title: 'Default Values and Controlling',
   description: `

--- a/docs/src/components/Components/TextFields/__tests__/__snapshots__/FormExample.jsx.snap
+++ b/docs/src/components/Components/TextFields/__tests__/__snapshots__/FormExample.jsx.snap
@@ -276,6 +276,7 @@ exports[`FormExample should render correctly 1`] = `
         <input
           aria-hidden={true}
           aria-label={undefined}
+          aria-labelledby={undefined}
           checked={false}
           className="md-selection-control-input"
           disabled={undefined}
@@ -327,6 +328,7 @@ exports[`FormExample should render correctly 1`] = `
           <input
             aria-hidden={true}
             aria-label={undefined}
+            aria-labelledby={undefined}
             checked={true}
             className="md-selection-control-input"
             disabled={undefined}
@@ -372,6 +374,7 @@ exports[`FormExample should render correctly 1`] = `
           <input
             aria-hidden={true}
             aria-label={undefined}
+            aria-labelledby={undefined}
             checked={false}
             className="md-selection-control-input"
             disabled={undefined}
@@ -417,6 +420,7 @@ exports[`FormExample should render correctly 1`] = `
           <input
             aria-hidden={true}
             aria-label={undefined}
+            aria-labelledby={undefined}
             checked={false}
             className="md-selection-control-input"
             disabled={undefined}
@@ -462,6 +466,7 @@ exports[`FormExample should render correctly 1`] = `
           <input
             aria-hidden={true}
             aria-label={undefined}
+            aria-labelledby={undefined}
             checked={true}
             className="md-selection-control-input"
             disabled={undefined}
@@ -507,6 +512,7 @@ exports[`FormExample should render correctly 1`] = `
           <input
             aria-hidden={true}
             aria-label={undefined}
+            aria-labelledby={undefined}
             checked={false}
             className="md-selection-control-input"
             disabled={undefined}

--- a/docs/src/components/Customization/ThemeBuilder/__tests__/__snapshots__/Configuration.jsx.snap
+++ b/docs/src/components/Customization/ThemeBuilder/__tests__/__snapshots__/Configuration.jsx.snap
@@ -120,7 +120,7 @@ exports[`Configuration should render correctly 1`] = `
           </i>
         </div>
         <hr
-          class="md-divider md-divider--text-field md-divider--expand-from-undefined md-divider--select-field"
+          class="md-divider md-divider--text-field md-divider--expand-from-left md-divider--select-field"
         />
         <input
           id="primary"
@@ -168,7 +168,7 @@ exports[`Configuration should render correctly 1`] = `
           </i>
         </div>
         <hr
-          class="md-divider md-divider--text-field md-divider--expand-from-undefined md-divider--select-field"
+          class="md-divider md-divider--text-field md-divider--expand-from-left md-divider--select-field"
         />
         <input
           id="secondary"
@@ -218,7 +218,7 @@ exports[`Configuration should render correctly 1`] = `
           </i>
         </div>
         <hr
-          class="md-divider md-divider--text-field md-divider--expand-from-undefined md-divider--select-field"
+          class="md-divider md-divider--text-field md-divider--expand-from-left md-divider--select-field"
         />
         <input
           id="hue"
@@ -351,7 +351,7 @@ exports[`Configuration should render correctly 2`] = `
           </i>
         </div>
         <hr
-          class="md-divider md-divider--text-field md-divider--expand-from-undefined md-divider--select-field"
+          class="md-divider md-divider--text-field md-divider--expand-from-left md-divider--select-field"
         />
         <input
           id="primary"
@@ -399,7 +399,7 @@ exports[`Configuration should render correctly 2`] = `
           </i>
         </div>
         <hr
-          class="md-divider md-divider--text-field md-divider--expand-from-undefined md-divider--select-field"
+          class="md-divider md-divider--text-field md-divider--expand-from-left md-divider--select-field"
         />
         <input
           id="secondary"
@@ -449,7 +449,7 @@ exports[`Configuration should render correctly 2`] = `
           </i>
         </div>
         <hr
-          class="md-divider md-divider--text-field md-divider--expand-from-undefined md-divider--select-field"
+          class="md-divider md-divider--text-field md-divider--expand-from-left md-divider--select-field"
         />
         <input
           id="hue"
@@ -581,7 +581,7 @@ exports[`Configuration should render correctly 3`] = `
           </i>
         </div>
         <hr
-          class="md-divider md-divider--text-field md-divider--expand-from-undefined md-divider--select-field"
+          class="md-divider md-divider--text-field md-divider--expand-from-left md-divider--select-field"
         />
         <input
           id="primary"
@@ -629,7 +629,7 @@ exports[`Configuration should render correctly 3`] = `
           </i>
         </div>
         <hr
-          class="md-divider md-divider--text-field md-divider--expand-from-undefined md-divider--select-field"
+          class="md-divider md-divider--text-field md-divider--expand-from-left md-divider--select-field"
         />
         <input
           id="secondary"
@@ -679,7 +679,7 @@ exports[`Configuration should render correctly 3`] = `
           </i>
         </div>
         <hr
-          class="md-divider md-divider--text-field md-divider--expand-from-undefined md-divider--select-field"
+          class="md-divider md-divider--text-field md-divider--expand-from-left md-divider--select-field"
         />
         <input
           id="hue"
@@ -810,7 +810,7 @@ exports[`Configuration should render correctly 4`] = `
           </i>
         </div>
         <hr
-          class="md-divider md-divider--text-field md-divider--expand-from-undefined md-divider--select-field"
+          class="md-divider md-divider--text-field md-divider--expand-from-left md-divider--select-field"
         />
         <input
           id="primary"
@@ -858,7 +858,7 @@ exports[`Configuration should render correctly 4`] = `
           </i>
         </div>
         <hr
-          class="md-divider md-divider--text-field md-divider--expand-from-undefined md-divider--select-field"
+          class="md-divider md-divider--text-field md-divider--expand-from-left md-divider--select-field"
         />
         <input
           id="secondary"
@@ -908,7 +908,7 @@ exports[`Configuration should render correctly 4`] = `
           </i>
         </div>
         <hr
-          class="md-divider md-divider--text-field md-divider--expand-from-undefined md-divider--select-field"
+          class="md-divider md-divider--text-field md-divider--expand-from-left md-divider--select-field"
         />
         <input
           id="hue"

--- a/docs/src/components/Customization/ThemeBuilder/__tests__/__snapshots__/index.jsx.snap
+++ b/docs/src/components/Customization/ThemeBuilder/__tests__/__snapshots__/index.jsx.snap
@@ -125,7 +125,7 @@ exports[`ThemeBuilder should render correctly 1`] = `
             </i>
           </div>
           <hr
-            class="md-divider md-divider--text-field md-divider--expand-from-undefined md-divider--select-field"
+            class="md-divider md-divider--text-field md-divider--expand-from-left md-divider--select-field"
           />
           <input
             id="primary"
@@ -175,7 +175,7 @@ exports[`ThemeBuilder should render correctly 1`] = `
             </i>
           </div>
           <hr
-            class="md-divider md-divider--text-field md-divider--expand-from-undefined md-divider--select-field"
+            class="md-divider md-divider--text-field md-divider--expand-from-left md-divider--select-field"
           />
           <input
             id="secondary"
@@ -225,7 +225,7 @@ exports[`ThemeBuilder should render correctly 1`] = `
             </i>
           </div>
           <hr
-            class="md-divider md-divider--text-field md-divider--expand-from-undefined md-divider--select-field"
+            class="md-divider md-divider--text-field md-divider--expand-from-left md-divider--select-field"
           />
           <input
             id="hue"

--- a/src/js/Menus/Menu.js
+++ b/src/js/Menus/Menu.js
@@ -37,6 +37,7 @@ export default class Menu extends PureComponent {
           'in the next major release. To make the `Menu` behave as a context menu, provide ' +
           'the `onContextMenu` prop instead.'
         );
+        /* eslint-enable no-console */
       }
 
       this._warned = true;
@@ -419,6 +420,24 @@ export default class Menu extends PureComponent {
     }
   };
 
+  /**
+   * Checks if a provided event target or HTML Element is considered a menu click target.
+   * This normally is just a ListItem.
+   */
+  _isCloseTarget(target) {
+    return target.classList.contains('md-list-item')
+      && !target.classList.contains('md-list-item--nested-container');
+  }
+
+  /**
+   * Checks if a provided event target or HTML Element is something that should shortcut/break
+   * out of the click event loop because it **should not** close menus when clicked.
+   */
+  _isIgnoreTarget(target) {
+    return target.getAttribute('disabled') !== null
+      || target.classList.contains('md-list-control');
+  }
+
   _handleClick = (e) => {
     if (this.props.onClick) {
       this.props.onClick(e);
@@ -426,13 +445,11 @@ export default class Menu extends PureComponent {
 
     let node = e.target;
     while (this._container && this._container.contains(node)) {
-      if (node.classList.contains('md-list-control')) {
+      if (this._isIgnoreTarget(node)) {
         return;
-      } else if (
-        !node.classList.contains('md-list-item--nested-container') &&
-        node.classList.contains('md-list-item')
-      ) {
+      } else if (this._isCloseTarget(node)) {
         e.persist();
+        // set a timeout so item click events still trigger, and then close
         this._timeout = setTimeout(() => {
           this._timeout = null;
           this._handleClose(e);

--- a/src/js/Menus/__tests__/Menu.js
+++ b/src/js/Menus/__tests__/Menu.js
@@ -305,4 +305,32 @@ describe('Menu', () => {
     jest.runAllTimers();
     expect(onClose.mock.calls.length).toBe(0);
   });
+
+  it('should not call the onClose function when a ListItem is disabled', () => {
+    const onClose = jest.fn();
+    const menu = mount(
+      <Menu id="test" visible onClose={onClose}>
+        <ListItem primaryText="My Test" disabled />
+        <ListItem primaryText="My Test 2" />
+      </Menu>
+    );
+
+    const item = menu.find(ListItem).at(0);
+    expect(item.props().disabled).toBe(true);
+    const event = {
+      target: {
+        // get attr isn't defined in tests, so mock it just like browser does
+        getAttribute(attr) {
+          if (attr === 'disabled') {
+            return '';
+          }
+
+          return null;
+        },
+      },
+    };
+    item.simulate('click', event);
+    jest.runAllTimers();
+    expect(onClose.mock.calls.length).toBe(0);
+  });
 });

--- a/src/js/SelectFields/SelectField.d.ts
+++ b/src/js/SelectFields/SelectField.d.ts
@@ -20,7 +20,7 @@ export interface SharedSelectFieldProps extends BaseMenuProps, SharedTextFieldPr
   defaultVisible?: boolean;
   visible?: boolean;
   onVisibilityChange?: (visible: boolean, event: React.MouseEvent<HTMLElement>) => void;
-  menuItems?: Array<number | string | Object>;
+  menuItems?: Array<number | string | Object | React.ReactElement<any>>;
   keyboardMatchingTimeout?: number;
   itemLabel?: string;
   itemValue?: string;

--- a/src/js/SelectFields/SelectField.js
+++ b/src/js/SelectFields/SelectField.js
@@ -876,7 +876,7 @@ export default class SelectField extends PureComponent {
     const search = `${lastSearch || ''}${letter}`.toUpperCase();
     menuItems.some((item, index) => {
       const label = String(this._getItemPart(item, itemLabel, itemValue, true));
-      if (label && label.toUpperCase().indexOf(search) === 0) {
+      if (label && label.toUpperCase().replace(/\s/g, '').indexOf(search) === 0) {
         match = index;
       }
 

--- a/src/js/SelectFields/SelectField.js
+++ b/src/js/SelectFields/SelectField.js
@@ -486,6 +486,11 @@ export default class SelectField extends PureComponent {
      */
     fillViewportHeight: PropTypes.bool,
 
+    /**
+     * The direction that the underline should appear from.
+     */
+    lineDirection: PropTypes.oneOf(['left', 'center', 'right']).isRequired,
+
     iconChildren: deprecated(PropTypes.node, 'Use `dropdownIcon` instead'),
     iconClassName: deprecated(PropTypes.string, 'Use `dropdownIcon` instead'),
     isOpen: deprecated(PropTypes.bool, 'Use `visible` instead'),
@@ -516,6 +521,7 @@ export default class SelectField extends PureComponent {
     itemLabel: 'label',
     itemValue: 'value',
     dropdownIcon: <FontIcon>arrow_drop_down</FontIcon>,
+    lineDirection: 'left',
     menuItems: [],
     defaultValue: '',
     defaultVisible: false,

--- a/src/js/SelectFields/SelectField.js
+++ b/src/js/SelectFields/SelectField.js
@@ -132,6 +132,7 @@ export default class SelectField extends PureComponent {
       PropTypes.number,
       PropTypes.string,
       PropTypes.object,
+      PropTypes.element,
     ])).isRequired,
 
     /**
@@ -927,6 +928,9 @@ export default class SelectField extends PureComponent {
 
   _reduceItems = (items, item, i) => {
     if (item === null) {
+      return items;
+    } else if (React.isValidElement(item)) {
+      items.push(item);
       return items;
     }
 

--- a/src/js/SelectFields/SelectField.js
+++ b/src/js/SelectFields/SelectField.js
@@ -736,7 +736,7 @@ export default class SelectField extends PureComponent {
     if (visible && this._container) {
       let node = e.target;
       while (this._container.contains(node)) {
-        if (typeof node.dataset.id !== 'undefined') {
+        if (node.dataset && typeof node.dataset.id !== 'undefined') {
           const { id, value } = node.dataset;
           this._selectItem(parseInt(id, 10), value, e);
           return;
@@ -881,6 +881,10 @@ export default class SelectField extends PureComponent {
     let match = -1;
     const search = `${lastSearch || ''}${letter}`.toUpperCase();
     menuItems.some((item, index) => {
+      if (item && typeof item === 'object' && item.disabled) {
+        return false;
+      }
+
       const label = String(this._getItemPart(item, itemLabel, itemValue, true));
       if (label && label.toUpperCase().replace(/\s/g, '').indexOf(search) === 0) {
         match = index;
@@ -941,18 +945,19 @@ export default class SelectField extends PureComponent {
     const active = dataValue === value || dataValue === parseInt(value, 10);
     const stripped = (typeof stripActiveItem !== 'undefined' ? stripActiveItem : below) && active;
     if (!stripped) {
+      const disabled = (props && props.disabled) || false;
       items.push(
         <ListItem
           {...props}
-          ref={this._setListItem}
+          ref={disabled ? null : this._setListItem}
           id={active ? `${id}-options-active` : null}
           active={active}
           tabIndex={-1}
           primaryText={primaryText}
           key={item.key || dataValue}
           role="option"
-          data-id={i}
-          data-value={dataValue}
+          data-id={disabled ? null : i}
+          data-value={disabled ? null : dataValue}
         />
       );
     }


### PR DESCRIPTION
This PR updates the `SelectField` so that specific items can be disabled by just applying `disabled: true` to the item.

```
const menuItems = [{ label: 'Disabled Item', value: 0, disabled: true }];
```

In addition, the `SelectField` can render any valid React element even if it ignores it in all the component selection logic.

This PR also
- fixed the `undefined` lineDirection that was added to the SelectField's toggle
- updated the tab-focus logic for the SelectField items to be a _bit_ better.
- updated the keyboard typing-matching to ignore spaces