### PR TITLE
Typescript: Make `springConfig` of `Collapse` optional

### DIFF
--- a/src/js/Helpers/Collapse.d.ts
+++ b/src/js/Helpers/Collapse.d.ts
@@ -4,7 +4,7 @@ import { Props } from '../index';
 export interface CollapseProps extends Props {
   defaultStyle?: React.CSSProperties;
   collapsed: boolean;
-  springConfig: Object;
+  springConfig?: Object;
   children?: React.ReactElement<any>;
   animate?: boolean;
 }


### PR DESCRIPTION
Since it has a default value, it's not required to be set when using the component.
