### PR TITLE
disableOuterDates is optional

### DIFF
--- a/src/js/Pickers/DatePickerContainer.d.ts
+++ b/src/js/Pickers/DatePickerContainer.d.ts
@@ -23,7 +23,7 @@ export interface DatePickerProps extends BasePickerProps {
   calendarWeekdayClassName?: string;
   calendarWeekdayFormat?: NSL;
   showAllDays?: boolean;
-  disableOuterDates: boolean;
+  disableOuterDates?: boolean;
 
   /**
    * @deprecated


### PR DESCRIPTION
I assume this is correct. Docs are a bit unclear about default value, but I tracked the usage [to here](https://github.com/mlaursen/react-md/blob/master/src/js/Pickers/CalendarMonth.js#L129) and looks like it is `false` (since `undefined` will be falsy).
