### PR TITLE
Fix Typescript definitions for TableRow.onCheckboxClick and DataTable.onRowToggle

### DIFF
--- a/src/js/DataTables/DataTable.d.ts
+++ b/src/js/DataTables/DataTable.d.ts
@@ -13,7 +13,7 @@ export interface DataTableProps extends Props {
   defaultSelectedRows?: Array<boolean>;
   responsive?: boolean;
   plain?: boolean;
-  onRowToggle?: (rowId: number, checked: boolean, event: React.MouseEvent<HTMLElement>) => void;
+  onRowToggle?: (rowId: number, checked: boolean, selectedCount: number, event: React.MouseEvent<HTMLElement>) => void;
   children?: React.ReactNode;
   selectableRows?: boolean;
   indeterminate?: boolean;

--- a/src/js/DataTables/TableRow.d.ts
+++ b/src/js/DataTables/TableRow.d.ts
@@ -3,7 +3,7 @@ import { Props } from '../index';
 
 export interface TableRowProps extends Props {
   children?: Array<React.ReactElement<any>> | React.ReactElement<any>;
-  onCheckboxClick?: (rowIndex: number, event: React.MouseEvent<HTMLTableRowElement>) => void;
+  onCheckboxClick?: (rowIndex: number, checked: boolean, event: React.MouseEvent<HTMLTableRowElement>) => void;
   selected?: boolean;
   selectable?: boolean;
 

--- a/src/js/DataTables/TableRow.js
+++ b/src/js/DataTables/TableRow.js
@@ -43,8 +43,8 @@ export default class TableRow extends Component {
 
     /**
      * A function to call when the checkbox is clicked. This
-     * function will will be called with `(rowIndex, event)`. The
-     * `TableBody` and `TableHeader` components will automatically
+     * function will will be called with `(rowIndex, checked, event)`.
+     * The `TableBody` and `TableHeader` components will automatically
      * merge in a function to toggle the checkbox.
      */
     onCheckboxClick: PropTypes.func,


### PR DESCRIPTION
Typescript definitions are updated to match call signatures.

