### PR TITLE
[Slider] Fix value miscalculation when min and step are defined  (fixes #585)

### DIFF
--- a/docs/src/components/Components/Sliders/CustomRangeAndTicks.jsx
+++ b/docs/src/components/Components/Sliders/CustomRangeAndTicks.jsx
@@ -11,6 +11,15 @@ const CustomRangeAndTicks = () => (
       step={0.5}
     />
     <Slider
+      id="custom-range-step-slider"
+      label="Discrete Min = 1, Max = 3, Step = 0.25"
+      min={1}
+      max={3}
+      step={0.25}
+      valuePrecision={2}
+      discrete
+    />
+    <Slider
       id="disctete-ticks-slider"
       label="Discrete with ticks and precision"
       discrete

--- a/src/js/utils/NumberUtils/__tests__/calculateValueDistance.js
+++ b/src/js/utils/NumberUtils/__tests__/calculateValueDistance.js
@@ -45,4 +45,34 @@ describe('calculateValueDistance', () => {
     });
     expect(calculateValueDistance(pageX, width, left, scale, step, min, max, normalized)).toEqual(expected);
   });
+
+  describe('handle min values with step < 1', () => {
+    const value = 1.75;
+    const pxOffset = 5;
+    const width = 210;
+    const left = 0;
+    const step = 0.25;
+    const min = 1;
+    const max = 3;
+    // introduce an error of pxOffset to demonstrate it is rounding to nearest step
+    const pageX = (value - min) / (max - min) * width + left - pxOffset;
+    const scale = (max - min) / step;
+    it('should correctly round the value to the nearest step with normalized = false', () => {
+      const normalized = false;
+      const expected = expect.objectContaining({
+        value,
+        distance: (pageX - left) / width * 100,
+      });
+      expect(calculateValueDistance(pageX, width, left, scale, step, min, max, normalized)).toEqual(expected);
+    });
+    it('should correctly round the value and the distance to the nearest step with normalized = true', () => {
+      // modify to test normalized calculation
+      const normalized = true;
+      const expected = expect.objectContaining({
+        value,
+        distance: (pageX + pxOffset - left) / width * 100, // it should compensate for the error introduced above
+      });
+      expect(calculateValueDistance(pageX, width, left, scale, step, min, max, normalized)).toEqual(expected);
+    });
+  });
 });

--- a/src/js/utils/NumberUtils/calculateValueDistance.js
+++ b/src/js/utils/NumberUtils/calculateValueDistance.js
@@ -65,15 +65,9 @@ export default function calculateValueDistance(x, width, left, scale, step, min,
     }
 
     distance = value / scale * 100;
-    value += min;
+    value = (value * step) + min;
   } else {
-    value = min + Math.round(distance / 100 * scale);
-  }
-
-  if (step > 1) {
-    value *= step;
-  } else if (step > 0 && step < 1) {
-    value *= step;
+    value = min + step * Math.round(distance / 100 * scale);
   }
 
   return {


### PR DESCRIPTION
Update the `calculateValueDistance `utility to apply scale to the value and _then_ add the minumum.  Previously the scale was applied after adding the minimum, leading to incorrect slider behavior.

- two new tests to test `calculateValueDistance `when a minimum and a step is specified, with `normalized `both `true` and `false`
- Updated docs to show example of a discrete slider with min and step defined and the correct values displayed
- Passes all tests
- All modified files lint with no warnings or errors.

fixes #585