### PR TITLE
Export the Component from typescript definition files

### DIFF
--- a/src/js/Buttons/Button.d.ts
+++ b/src/js/Buttons/Button.d.ts
@@ -43,7 +43,7 @@ export interface ButtonProps extends Props, SharedButtonProps, InjectedTooltipPr
   fixedPosition?: FixedPositions;
 }
 
-interface ButtonComponent extends React.ComponentClass<ButtonProps> {
+export interface ButtonComponent extends React.ComponentClass<ButtonProps> {
   createInk(pageX?: number, pageY?: number): void;
   focus(): void;
   getComposedComponent(): TooltippedComponent;

--- a/src/js/DataTables/DropdownMenuColumn.d.ts
+++ b/src/js/DataTables/DropdownMenuColumn.d.ts
@@ -11,7 +11,7 @@ export interface DropdownMenuColumnProps extends DropdownMenuProps {
   tooltipPosition?: Positions;
 }
 
-interface DropdownMenuColumnComponent extends React.ComponentClass<DropdownMenuColumnProps> {
+export interface DropdownMenuColumnComponent extends React.ComponentClass<DropdownMenuColumnProps> {
   Positions: {
     TOP_LEFT: 'tl',
     TOP_RIGHT: 'tr',

--- a/src/js/DataTables/MenuButtonColumn.d.ts
+++ b/src/js/DataTables/MenuButtonColumn.d.ts
@@ -11,7 +11,7 @@ export interface MenuButtonColumnProps extends MenuButtonProps {
   tooltipPosition?: Positions;
 }
 
-interface MenuButtonColumnComponent extends React.ComponentClass<MenuButtonColumnProps> {
+export interface MenuButtonColumnComponent extends React.ComponentClass<MenuButtonColumnProps> {
   Positions: {
     TOP_LEFT: 'tl',
     TOP_RIGHT: 'tr',

--- a/src/js/DataTables/SelectFieldColumn.d.ts
+++ b/src/js/DataTables/SelectFieldColumn.d.ts
@@ -25,7 +25,7 @@ export interface SelectFieldColumnProps extends SharedSelectFieldProps, Injected
   wrapperClassName?: string;
 }
 
-interface SelectFieldColumnComponent extends React.ComponentClass<SelectFieldColumnProps> {
+export interface SelectFieldColumnComponent extends React.ComponentClass<SelectFieldColumnProps> {
   Positions: {
     TOP_LEFT: 'tl',
     TOP_RIGHT: 'tr',

--- a/src/js/Drawers/Drawer.d.ts
+++ b/src/js/Drawers/Drawer.d.ts
@@ -49,7 +49,7 @@ export interface DrawerProps extends Props {
   onVisibilityToggle?: (visible: boolean, event: React.MouseEvent<HTMLElement>) => void;
 }
 
-interface DrawerComponent extends React.ComponentClass<DrawerProps> {
+export interface DrawerComponent extends React.ComponentClass<DrawerProps> {
   DrawerTypes: {
     // Permanent drawers
     FULL_HEIGHT: 'full-height',

--- a/src/js/FileInputs/FileUpload.d.ts
+++ b/src/js/FileInputs/FileUpload.d.ts
@@ -13,7 +13,7 @@ export interface FileUploadProps extends FileInputProps {
   onProgress?: (file: File, progress: number, event: Event) => void;
 }
 
-interface FileUploadComponent extends React.ComponentClass<FileUploadProps> {
+export interface FileUploadComponent extends React.ComponentClass<FileUploadProps> {
   abort(file: string | File): void;
 }
 

--- a/src/js/Grids/Cell.d.ts
+++ b/src/js/Grids/Cell.d.ts
@@ -24,7 +24,7 @@ export interface CellProps extends Props {
   desktopHidden?: boolean;
 }
 
-interface CellComponent extends React.ComponentClass<CellProps> {
+export interface CellComponent extends React.ComponentClass<CellProps> {
   getClassName(props?: CellProps): string;
 }
 

--- a/src/js/Grids/Grid.d.ts
+++ b/src/js/Grids/Grid.d.ts
@@ -12,7 +12,7 @@ export interface GridProps extends Props {
   spacing?: number;
 }
 
-interface GridComponent extends React.ComponentClass<GridProps> {
+export interface GridComponent extends React.ComponentClass<GridProps> {
   getClassName(props?: GridProps): string;
 }
 

--- a/src/js/Grids/GridList.d.ts
+++ b/src/js/Grids/GridList.d.ts
@@ -16,7 +16,7 @@ export interface GridListProps extends Props, GridProps, CellProps {
   cellClassName?: string;
 }
 
-interface GridListComponent extends React.ComponentClass<GridListProps> {
+export interface GridListComponent extends React.ComponentClass<GridListProps> {
   getClassNames(props?: GridListProps): { className: string, cellClassName: string };
 }
 

--- a/src/js/Helpers/AccessibleFakeButton.d.ts
+++ b/src/js/Helpers/AccessibleFakeButton.d.ts
@@ -15,7 +15,7 @@ export interface AccessibleFakeButtonProps {
   children?: React.ReactNode;
 }
 
-interface AccessibleFakeButtonComponent extends React.ComponentClass<AccessibleFakeButtonProps> {
+export interface AccessibleFakeButtonComponent extends React.ComponentClass<AccessibleFakeButtonProps> {
   focus: () => void;
   blur: () => void;
 }

--- a/src/js/Helpers/Layover.d.ts
+++ b/src/js/Helpers/Layover.d.ts
@@ -67,7 +67,7 @@ export interface LayoverProps extends SharedLayoverProps {
   simplified?: boolean;
 }
 
-interface LayoverComponent extends React.ComponentClass<LayoverProps> {
+export interface LayoverComponent extends React.ComponentClass<LayoverProps> {
   Positions: {
     TOP_LEFT: 'tl',
     TOP_RIGHT: 'tr',

--- a/src/js/Lists/ListItem.d.ts
+++ b/src/js/Lists/ListItem.d.ts
@@ -71,7 +71,7 @@ export interface ListItemProps extends BaseListItemProps, InjectedInkProps {
   expanderIconClassName?: string;
 }
 
-interface ListItemComponent extends React.ComponentClass<ListItemProps> {
+export interface ListItemComponent extends React.ComponentClass<ListItemProps> {
   focus(): void;
   blur(): void;
 }

--- a/src/js/Menus/DropdownMenu.d.ts
+++ b/src/js/Menus/DropdownMenu.d.ts
@@ -19,7 +19,7 @@ export interface DropdownMenuProps extends SharedDropdownMenuProps {
   children?: React.ReactElement<any>;
 }
 
-interface DropdownMenuComponent extends React.ComponentClass<DropdownMenuProps> {
+export interface DropdownMenuComponent extends React.ComponentClass<DropdownMenuProps> {
   Positions: LayoverPositions;
   HorizontalAnchors: HorizontalAnchors;
   VerticalAnchors: VerticalAnchors;

--- a/src/js/Menus/Menu.d.ts
+++ b/src/js/Menus/Menu.d.ts
@@ -71,7 +71,7 @@ export interface MenuProps extends BaseMenuProps {
   expanderIconChildren?: React.ReactNode;
 }
 
-interface MenuComponent extends React.ComponentClass<MenuProps> {
+export interface MenuComponent extends React.ComponentClass<MenuProps> {
   Positions: LayoverPositions;
   HorizontalAnchors: HorizontalAnchors;
   VerticalAnchors: VerticalAnchors;

--- a/src/js/Menus/MenuButton.d.ts
+++ b/src/js/Menus/MenuButton.d.ts
@@ -31,7 +31,7 @@ export interface MenuButtonProps extends SharedDropdownMenuProps, SharedButtonPr
   defaultOpen?: boolean;
 }
 
-interface MenuButtonComponent extends React.ComponentClass<MenuButtonProps> {
+export interface MenuButtonComponent extends React.ComponentClass<MenuButtonProps> {
   Positions: LayoverPositions;
   HorizontalAnchors: HorizontalAnchors;
   VerticalAnchors: VerticalAnchors;

--- a/src/js/NavigationDrawers/NavigationDrawer.d.ts
+++ b/src/js/NavigationDrawers/NavigationDrawer.d.ts
@@ -93,7 +93,7 @@ export interface NavigationDrawerProps extends Props {
   persistentIconClassName?: string;
 }
 
-interface NavigationDrawerComponent extends React.ComponentClass<NavigationDrawerProps> {
+export interface NavigationDrawerComponent extends React.ComponentClass<NavigationDrawerProps> {
   DrawerTypes: {
     // Permanent drawers
     FULL_HEIGHT: 'full-height',

--- a/src/js/SelectFields/SelectField.d.ts
+++ b/src/js/SelectFields/SelectField.d.ts
@@ -105,7 +105,7 @@ export interface SelectFieldProps extends SharedSelectFieldProps {
   iconClassName?: string;
 }
 
-interface SelectFieldComponent extends React.ComponentClass<SelectFieldProps> {
+export interface SelectFieldComponent extends React.ComponentClass<SelectFieldProps> {
   Positions: {
     TOP_LEFT: 'tl',
     TOP_RIGHT: 'tr',

--- a/src/js/TextFields/TextField.d.ts
+++ b/src/js/TextFields/TextField.d.ts
@@ -75,11 +75,10 @@ export interface TextFieldProps extends SharedTextFieldProps, Props {
   adjustMinWidth?: boolean;
 }
 
-interface TextFieldComponent extends React.ComponentClass<TextFieldProps> {
+export interface TextFieldComponent extends React.ComponentClass<TextFieldProps> {
   focus(): void;
   getField(): React.ReactHTMLElement<any> | null; // should be input or textarea, but get warning
 }
 
 declare const TextField: TextFieldComponent;
 export default TextField;
-


### PR DESCRIPTION
When using refs (e.g. on TextField), the Component type is the
type of the reference. In order to be able to run methods on
the referenced component, the type must be exported.

```
import TextField, { TextFieldComponent } from 'react-md/lib/TextFields';

// ...

  <TextField ref={(ref: TextFieldComponent) => ref.focus()} />
```

If the component type is not exported, it's not possible to call
methods in a typesafe manner.