### PR TITLE
Confusion over Layover.d.ts

### DIFF
--- a/src/js/Helpers/Layover.d.ts
+++ b/src/js/Helpers/Layover.d.ts
@@ -3,19 +3,19 @@ import { IdPropType, Props } from '../index';
 
 export type toggleQueryFn = () => string;
 
-export type HorizontalAnchors = {
-  LEFT: 'left',
-  INNER_LEFT: 'inner left',
-  CENTER: 'center',
-  RIGHT: 'right',
-  INNER_RIGHT: 'inner right'
+export enum HorizontalAnchors {
+  LEFT = 'left',
+  INNER_LEFT = 'inner left',
+  CENTER = 'center',
+  RIGHT = 'right',
+  INNER_RIGHT = 'inner right'
 }
 
-export type VerticalAnchors = {
-  TOP: 'top',
-  CENTER: 'center',
-  OVERLAP: 'overlap',
-  BOTTOM: 'bottom'
+export enum VerticalAnchors {
+  TOP = 'top',
+  CENTER = 'center',
+  OVERLAP = 'overlap',
+  BOTTOM = 'bottom'
 }
 
 export type LayoverPositions = 'tl' | 'tr' | 'bl' | 'br' | 'below';


### PR DESCRIPTION
Apologies for not following the PR process but I'm uncertain if I'm doing this right - this is more of a suggestion/hint than a fix...

I'm unable to initialise a the anchors for a menu in Typescript. Code similar to the the examples gives an error. For example:
```
    <DropdownMenu
      id={`dropdown-menu`}
      menuItems={['Preferences', 'About', { divider: true }, 'Log out']}
      sameWidth={true}
      simplifiedMenu={false}
      anchor={{
        x: DropdownMenu.HorizontalAnchors.CENTER,
        y: DropdownMenu.VerticalAnchors.BOTTOM
      }}
    >
```

Gives an error like:
```
(134,7): error TS2322: Type '{ id: string; menuItems: ("Preferences" | "About" | { divider: boolean; } | "Log out")[]; sameWid...' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<DropdownMenuProps, ComponentState>> & Re...'.
  Type '{ id: string; menuItems: ("Preferences" | "About" | { divider: boolean; } | "Log out")[]; sameWid...' is not assignable to type 'Readonly<DropdownMenuProps>'.
    Types of property 'anchor' are incompatible.
      Type '{ x: "center"; y: "bottom"; }' is not assignable to type 'LayoverAnchor | undefined'.
        Type '{ x: "center"; y: "bottom"; }' is not assignable to type 'LayoverAnchor'.
          Types of property 'x' are incompatible.
            Type '"center"' is not assignable to type 'HorizontalAnchors'.
```
I can't make any sense of the type definitions - is this a bug? Does the patch make sense?