### PR TITLE
[Autocomplete] Updated the filter prop and added some more props to the typescript definitions.

### DIFF
--- a/src/js/Autocompletes/Autocomplete.d.ts
+++ b/src/js/Autocompletes/Autocomplete.d.ts
@@ -31,7 +31,7 @@ export interface AutocompleteProps extends BaseMenuProps {
   data: DataType;
   total?: number;
   offset?: number;
-  filter?: (data: DataType, filterText: string | number, dataLabel?: string) => Array<string>;
+  filter?: null | ((data: DataType, filterText: string | number, dataLabel?: string) => Array<string>);
   inline?: boolean;
   findInlineSuggestion?: (data: DataType, value: string | number, dataLabel?: string) => string | number;
   autocompleteWithLabel?: boolean;
@@ -45,6 +45,11 @@ export interface AutocompleteProps extends BaseMenuProps {
   position?: LayoverPositions;
   simplifiedMenu?: boolean;
   toolbar?: boolean;
+  customSize?: string;
+  inlineIndicator?: React.ReactElement<any>;
+  helpText?: string;
+  helpOnFocus?: boolean;
+  error?: boolean;
 }
 
 interface AutocompleteComponent extends React.ComponentClass<AutocompleteProps> {


### PR DESCRIPTION
Filter doesn't accept null as an input, but the docs say that it should, so I updated it.

Additionally, there are a few useful props that work on the component that I added:

```
customSize?: any;
inlineIndicator?: any;
helpText?: string;
helpOnFocus?: boolean;
error?: boolean;
```

Many of these are defined on Text Fields but aren't in the docs for the autocomplete component despite working just fine.