### PR TITLE
Allows contenteditable in handleKeyboardAccessibility util

### DIFF
--- a/src/js/utils/EventUtils/handleKeyboardAccessibility.js
+++ b/src/js/utils/EventUtils/handleKeyboardAccessibility.js
@@ -31,7 +31,9 @@ export default function handleKeyboardAccessibility(e, onClick, listenToEnter = 
   const enter = key === ENTER;
 
   const { tagName } = e.target;
-  if (space && !tagName.match(/input|textarea|button/i)) { // it is valid to press space in text fields and buttons
+  const isContentEditable = e.target.getAttribute('contenteditable') === "true";
+  if (space && !tagName.match(/input|textarea|button/i) &&
+    !isContentEditable) { // it is valid to press space in text fields and buttons
     // Stop page scrolling
     e.preventDefault();
   }


### PR DESCRIPTION
handleKeyboardAccessibility util checks if event occurs in input or textarea,
but does not take into account contenteditable elements, which breaks space
button in such elements. This change will address that issue.
