### PR TITLE
#662 bugfix

### DIFF
--- a/src/js/Tabs/TabsContainer.js
+++ b/src/js/Tabs/TabsContainer.js
@@ -255,8 +255,8 @@ export default class TabsContainer extends PureComponent {
     }
 
     const activePanel = this._container.querySelector('.md-tab-panel[aria-hidden=false]');
-    if (activePanel && this.state.panelHeight !== activePanel.offsetHeight) {
-      this.setState({ panelHeight: activePanel.offsetHeight });
+    if (activePanel && this.state.panelHeight !== activePanel.scrollHeight) {
+      this.setState({ panelHeight: activePanel.scrollHeight });
     }
   };
 


### PR DESCRIPTION

Fixes #662 

Replace offsetHeight with scrollHeight to include margin to calculate panelHeight TabsContainer component.


