### PR TITLE
typo fix for avatar example

### DIFF
--- a/src/scss/components/_avatars.scss
+++ b/src/scss/components/_avatars.scss
@@ -154,7 +154,7 @@ $md-avatar-colors: (
 /// suffix.
 ///
 /// @example scss - Simple Example SCSS
-///   @include react-md-theme-avatars(#000, #fff, black);
+///   @include react-md-theme-avatar(#000, #fff, black);
 ///
 /// @example scss - Simple Example CSS Output
 ///   .md-avatar--black {


### PR DESCRIPTION
fix typo in example for `react-md-theme-avatar`