### PR TITLE
Add the possibility of customizing selection control

### DIFF
--- a/src/js/SelectionControls/SelectionControlGroup.d.ts
+++ b/src/js/SelectionControls/SelectionControlGroup.d.ts
@@ -10,6 +10,7 @@ export interface SelectionControlGroupProps extends Props {
   id?: IdPropType;
   type: 'checkbox' | 'radio';
   component?: React.ReactType;
+  selectionControl?: React.ReactType;
   label?: React.ReactNode;
   labelClassName?: string;
   labelComponent?: React.ReactType;

--- a/src/js/SelectionControls/SelectionControlGroup.js
+++ b/src/js/SelectionControls/SelectionControlGroup.js
@@ -265,7 +265,7 @@ export default class SelectionControlGroup extends PureComponent {
     component: 'fieldset',
     labelComponent: 'legend',
     labelClassName: 'md-subheading-1',
-    selectionControl: SelectionControl
+    selectionControl: SelectionControl,
   };
 
   constructor(props) {

--- a/src/js/SelectionControls/SelectionControlGroup.js
+++ b/src/js/SelectionControls/SelectionControlGroup.js
@@ -101,6 +101,14 @@ export default class SelectionControlGroup extends PureComponent {
     labelClassName: PropTypes.string,
 
     /**
+     * The component to render the `SelectionControl` in
+     */
+    selectionControl: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.func,
+    ]).isRequired,
+
+    /**
      * The component to render the optional `label` in.
      */
     labelComponent: PropTypes.oneOfType([
@@ -257,6 +265,7 @@ export default class SelectionControlGroup extends PureComponent {
     component: 'fieldset',
     labelComponent: 'legend',
     labelClassName: 'md-subheading-1',
+    selectionControl: SelectionControl
   };
 
   constructor(props) {
@@ -367,6 +376,7 @@ export default class SelectionControlGroup extends PureComponent {
       uncheckedRadioIcon,
       checkedCheckboxIcon,
       uncheckedCheckboxIcon,
+      selectionControl,
       /* eslint-disable no-unused-vars */
       value: propValue,
       controls: propControls,
@@ -403,7 +413,7 @@ export default class SelectionControlGroup extends PureComponent {
         className: cn(controlClassName, control.className),
       };
 
-      return <SelectionControl {...controlProps} />;
+      return React.createElement(selectionControl, controlProps);
     });
 
     let ariaLabel;


### PR DESCRIPTION
This feature provide the easy way to customize radio buttons, check-boxes and etc by using custom selection control.
```js
<SelectionControlGroup
         ...
          selectionControl=CustomSelectionControl
         ...
>
```

I suppose that it will be very useful.