### PR TITLE
Make primaryText an optional argument for BaseListItemProps

### DIFF
--- a/src/js/Lists/ListItem.d.ts
+++ b/src/js/Lists/ListItem.d.ts
@@ -5,6 +5,7 @@ import { InjectedInkProps } from '../Inks';
 export interface BaseListItemProps {
   tileStyle?: React.CSSProperties;
   tileClassName?: string;
+  primaryText?: React.ReactNode;
   secondaryText?: React.ReactNode;
   leftIcon?: React.ReactNode;
   leftAvatar?: React.ReactNode;


### PR DESCRIPTION
Fix for issue #734. Building off of release 1.3.X

This change makes the primaryText an optional argument for the BaseListItemProps (so it can be used in the ListItemControl), but leaves it as a required argument for the ListItem.

Tests pass with this change.