### PR TITLE
SelectField - Use parseFloat for numbers to allow decimals to work

### DIFF
--- a/src/js/SelectFields/SelectField.js
+++ b/src/js/SelectFields/SelectField.js
@@ -650,7 +650,7 @@ export default class SelectField extends PureComponent {
     const v = this._getItemPart(item, itemLabel, itemValue);
     const label = this._getItemPart(item, itemLabel, itemValue, true);
 
-    return v === value || v === parseInt(value, 10) ? label : '';
+    return v === value || v === parseFloat(value) ? label : '';
   };
 
   _getActive = (props, state) => {
@@ -970,7 +970,7 @@ export default class SelectField extends PureComponent {
     const dataValue = this._getItemPart(item, itemLabel, itemValue);
     const primaryText = this._getItemPart(item, itemLabel, itemValue, true);
 
-    const active = dataValue === value || dataValue === parseInt(value, 10);
+    const active = dataValue === value || dataValue === parseFloat(value);
     const stripped = (typeof stripActiveItem !== 'undefined' ? stripActiveItem : below) && active;
     if (!stripped) {
       const objectType = typeof item === 'object';

--- a/src/js/SelectFields/__tests__/SelectField.js
+++ b/src/js/SelectFields/__tests__/SelectField.js
@@ -79,6 +79,9 @@ describe('SelectField', () => {
 
       expect(field._getItemPart({ label: 0, value: 'a' }, 'label', 'value', false)).toBe('a');
       expect(field._getItemPart({ label: 0, value: 'a' }, 'label', 'value', true)).toBe(0);
+
+      expect(field._getItemPart({ label: 1.5, value: 'a' }, 'label', 'value', false)).toBe('a');
+      expect(field._getItemPart({ label: 1.5, value: 'a' }, 'label', 'value', true)).toBe(1.5);
     });
   });
 
@@ -103,6 +106,8 @@ describe('SelectField', () => {
       expect(field._getActiveItemLabel({ label: 'No Way', value: 0 }, '', 'label', 'value')).toBe('');
       expect(field._getActiveItemLabel({ label: 'No Way', value: '0' }, '', 'label', 'value')).toBe('');
       expect(field._getActiveItemLabel({ label: 'No Way', value: '' }, '', 'label', 'value')).toBe('No Way');
+      expect(field._getActiveItemLabel({ label: 'No Way', value: 3.5 }, '', 'label', 'value')).toBe('');
+      expect(field._getActiveItemLabel({ label: 'No Way', value: 3.5 }, '3.5', 'label', 'value')).toBe('No Way');
     });
   });
 


### PR DESCRIPTION
Fixes for https://github.com/mlaursen/react-md/issues/751