### PR TITLE
Reference where types are

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "index.d.ts",
     "LICENSE"
   ],
+  "types": "./index.d.ts",
   "scripts": {
     "lint:fix": "eslint -c .eslintrc --fix src",
     "lint:styles": "scss-lint src/scss",


### PR DESCRIPTION
Because of the `main` directive, typescript 2.9 now looks in `./lib/index.d.ts`
first, where it finds [this file](https://github.com/mlaursen/react-md/blob/master/src/js/index.d.ts).

This change specifically tells typescript to look at the `index.d.ts` in
the root of the built project.