### PR TITLE
Improve accessibility of selection controls and groups

### DIFF
--- a/src/js/SelectionControls/SelectionControl.js
+++ b/src/js/SelectionControls/SelectionControl.js
@@ -58,6 +58,13 @@ export default class SelectionControl extends PureComponent {
     ]),
 
     /**
+     * An optional id of an element that describes this selection control.
+     * In the case of a fieldset, this should be the id of the fieldset legend which ensures
+     * screen readers provides additional context about the selection control
+     */
+    'aria-describedby': PropTypes.string,
+
+    /**
      * An optional style to apply to the selection control's container.
      */
     style: PropTypes.object,
@@ -316,6 +323,7 @@ export default class SelectionControl extends PureComponent {
       disabledInteractions,
       'aria-label': ariaLabel,
       'aria-labelledby': ariaLabelledBy,
+      'aria-describedby': ariaDescribedBy,
       /* eslint-disable no-unused-vars */
       label: propLabel,
       checked: propChildren,
@@ -344,7 +352,7 @@ export default class SelectionControl extends PureComponent {
 
     const checked = getField(this.props, this.state, 'checked');
     const isSwitch = type === 'switch';
-    const label = this.props.label && <span>{this.props.label}</span>;
+    const label = this.props.label && <span id={`${id}-label`}>{this.props.label}</span>;
 
     let control;
     if (isSwitch) {
@@ -361,6 +369,9 @@ export default class SelectionControl extends PureComponent {
             secondary: checked,
           }))}
           aria-checked={checked}
+          aria-label={ariaLabel}
+          aria-labelledby={ariaLabelledBy || `${id}-label`}
+          aria-describedby={ariaDescribedBy}
           tabIndex={tabIndex}
           disabled={disabled}
         >
@@ -392,8 +403,6 @@ export default class SelectionControl extends PureComponent {
           name={name}
           value={value}
           aria-hidden
-          aria-label={ariaLabel}
-          aria-labelledby={ariaLabelledBy}
         />
         <label
           htmlFor={id}

--- a/src/js/SelectionControls/SelectionControlGroup.js
+++ b/src/js/SelectionControls/SelectionControlGroup.js
@@ -429,6 +429,7 @@ export default class SelectionControlGroup extends PureComponent {
         uncheckedRadioIcon,
         checkedCheckboxIcon,
         uncheckedCheckboxIcon,
+        'aria-describedby': `${id}-group-label`,
         ...control,
         style,
         className: cn(controlClassName, control.className),
@@ -439,7 +440,7 @@ export default class SelectionControlGroup extends PureComponent {
 
     let ariaLabel;
     if (label) {
-      ariaLabel = <LabelComponent className={labelClassName}>{label}</LabelComponent>;
+      ariaLabel = <LabelComponent className={labelClassName} id={`${id}-group-label`}>{label}</LabelComponent>;
     }
 
     return (


### PR DESCRIPTION
Currently selection controls and selection control groups are fairly inaccessible. 

The aria-label and labelledby are applied to the input field which is also aria-hidden. This means a screen reader will never read any details related to this field. Additionally the control (tab-able element) is actually the button and that is the control that needs to be labeled.

Also, possibly because the controls aren't real input fields, the fieldset label is never read (at least by VoiceOver which I used to test) as a description for the controls making it difficult to understand without the addition of the aria-describedby.

This is my first PR here so let me know what I can do to clean this up. There is likely some additional things that could be cleaned up here as well, but wanted to keep my first one small.