### PR TITLE
height needs to support css values in typescript

### DIFF
--- a/examples/with-create-react-app/README.md
+++ b/examples/with-create-react-app/README.md
@@ -90,7 +90,7 @@ $ touch src/_globals.scss
 are considered to be import-only files. This is exactly that we want since this should only be used for importing helpers, mixins,
 and variables into our other Sass files.
 
-Now let's update the `src/_globals.scss` file so that we import react-md and define a them:
+Now let's update the `src/_globals.scss` file so that we import react-md and define a theme:
 ```diff
 +@import 'react-md/src/scss/react-md';
 +

--- a/src/js/Dialogs/Dialog.d.ts
+++ b/src/js/Dialogs/Dialog.d.ts
@@ -26,8 +26,8 @@ export interface DialogProps extends Props {
   fullPage?: boolean;
   title?: React.ReactNode;
   autosizeContent?: boolean;
-  height?: number;
-  width?: number;
+  height?: number | string;
+  width?: number | string;
   stackedActions?: boolean;
 }
 


### PR DESCRIPTION
PropTypes shows string or number. but in typescript it's not accepted because of this

*Before* submitting a pull request, please make sure the following is done:

1. Fork the repo and create your branch from `release/MAJOR.MINOR.x`. At the time of creating this, react-md is at version v1.0.0, so you would branch off of `release/1.0.x`.
2. If you have added code that should be tested, please add tests.
3. If you have added new prop types or deprecated prop types, please update the docgen descriptions. When TypeScript is fully implemented, update the types as well.
4. Ensure that the test suite passes (`npm test`).
5. Ensure that your code lints (`npm run lint`).
  > NOTE: Sass changes rely on the Ruby version of `sass` and `scss-lint` to work.
  

6. If your pull request attempts to fix an existing issue, please reference that issue via a commit message or the pull request comment.
7. If this is a new feature or component that has a visual impact, please provide any screenshots or images.
