### PR TITLE
[Autocompletes] Add showUnfilteredData flag to show data on focus without value

### DIFF
--- a/examples/with-create-react-app/README.md
+++ b/examples/with-create-react-app/README.md
@@ -90,7 +90,7 @@ $ touch src/_globals.scss
 are considered to be import-only files. This is exactly that we want since this should only be used for importing helpers, mixins,
 and variables into our other Sass files.
 
-Now let's update the `src/_globals.scss` file so that we import react-md and define a them:
+Now let's update the `src/_globals.scss` file so that we import react-md and define a theme:
 ```diff
 +@import 'react-md/src/scss/react-md';
 +

--- a/src/js/Autocompletes/Autocomplete.d.ts
+++ b/src/js/Autocompletes/Autocomplete.d.ts
@@ -50,6 +50,7 @@ export interface AutocompleteProps extends BaseMenuProps {
   helpText?: string;
   helpOnFocus?: boolean;
   error?: boolean;
+  showUnfilteredData?: boolean;
 }
 
 interface AutocompleteComponent extends React.ComponentClass<AutocompleteProps> {

--- a/src/js/Autocompletes/Autocomplete.js
+++ b/src/js/Autocompletes/Autocomplete.js
@@ -487,6 +487,12 @@ export default class Autocomplete extends PureComponent {
      * @see {@link TextFields#toolbar}
      */
     toolbar: PropTypes.bool,
+
+    /**
+     * Boolean if the list of data should be shown on focus when no filter value has been
+     * provided.
+     */
+    showUnfilteredData: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -502,6 +508,7 @@ export default class Autocomplete extends PureComponent {
     autoComplete: 'off',
     repositionOnScroll: true,
     repositionOnResize: true,
+    showUnfilteredData: false,
     inlineSuggestionPadding: 6,
   };
 
@@ -513,12 +520,13 @@ export default class Autocomplete extends PureComponent {
       data,
       dataLabel,
       filter,
+      showUnfilteredData,
     } = props;
 
     let matches = [];
     if (defaultValue && filter) {
       matches = filter(data, defaultValue, dataLabel);
-    } else if (!filter) {
+    } else if (!filter || showUnfilteredData) {
       matches = data;
     }
 
@@ -582,7 +590,15 @@ export default class Autocomplete extends PureComponent {
   };
 
   _handleChange = (value, event) => {
-    const { onChange, filter, findInlineSuggestion, data, dataLabel, inline } = this.props;
+    const {
+      onChange,
+      filter,
+      findInlineSuggestion,
+      data,
+      dataLabel,
+      inline,
+      showUnfilteredData,
+    } = this.props;
 
     if (onChange) {
       onChange(value, event);
@@ -594,7 +610,9 @@ export default class Autocomplete extends PureComponent {
     }
 
     let { visible } = this.state;
-    let matches = value || !filter ? this.state.matches : [];
+    const hasValidValue = value || showUnfilteredData;
+
+    let matches = hasValidValue || !filter ? data : [];
     if (value && filter) {
       matches = filter(data, value, dataLabel);
     }
@@ -620,9 +638,11 @@ export default class Autocomplete extends PureComponent {
       return;
     }
 
+    const hasValidValue = !!value || this.props.showUnfilteredData;
+
     this.setState({
       matchIndex: -1,
-      visible: !this.state.manualFocus && !!value && !!this.state.matches.length,
+      visible: !this.state.manualFocus && hasValidValue && !!this.state.matches.length,
       manualFocus: false,
       focus: true,
     });
@@ -984,6 +1004,7 @@ export default class Autocomplete extends PureComponent {
       onKeyDown,
       onMouseDown,
       onChange,
+      showUnfilteredData,
       /* eslint-enable no-unused-vars */
       ...props
     } = this.props;

--- a/src/js/Autocompletes/__tests__/Autocomplete.js
+++ b/src/js/Autocompletes/__tests__/Autocomplete.js
@@ -160,6 +160,36 @@ describe('Autocomplete', () => {
     expect(autocomplete.state('focus')).toBe(false);
   });
 
+  it('should set the visible state to true on focus with a value', () => {
+    const data = ['Hello'];
+    const autocomplete = mount(<Autocomplete id="test" data={data} defaultValue="he" />);
+    const field = autocomplete.find('input');
+    expect(field.length).toBe(1);
+
+    field.simulate('focus');
+    expect(autocomplete.state('visible')).toBe(true);
+  });
+
+  it('should set the visible state to false on focus without value', () => {
+    const data = ['Hello'];
+    const autocomplete = mount(<Autocomplete id="test" data={data} defaultValue="" />);
+    const field = autocomplete.find('input');
+    expect(field.length).toBe(1);
+
+    field.simulate('focus');
+    expect(autocomplete.state('visible')).toBe(false);
+  });
+
+  it('should set the visible state to true on focus without value if the showUnfilteredData flag is set to true', () => {
+    const data = ['Hello'];
+    const autocomplete = mount(<Autocomplete id="test" data={data} defaultValue="" showUnfilteredData />);
+    const field = autocomplete.find('input');
+    expect(field.length).toBe(1);
+
+    field.simulate('focus');
+    expect(autocomplete.state('visible')).toBe(true);
+  });
+
   it('should call the onKeyDown prop when the onKeyDown event is fired on the text field', () => {
     const onKeyDown = jest.fn();
     const autocomplete = mount(<Autocomplete id="test" data={[]} onKeyDown={onKeyDown} />);


### PR DESCRIPTION
Resolves #781

This Pull Request aims to add the `showUnfilteredData` flag to the autocompletes props. It will be used to show the data on focus and change event even if no value is provided to the text box.
Note that the rest of the behavior should stay the same. 

As it is my first Pull Request on the repository please do not hesitate to point out things that I forgot or against the conventions. Please also feel free to reject the Pull Request if you think I am doing it completely wrong.


Also I noticed two things while working on the feature:
- The autocomplete without filter has inconsistent behavior
  - On focus it does not show the data
  - On change with an empty value it shows the data
- There is a trailing space in `docs/src/components/App/Footer/Contribute.jsx`
  - triggers some warning affecting readability

I can fix the second issue in another Pull Request. As for the first one do we want to behavior to be the same as with the `showUnfilteredData` flag? Maybe should we open another issue if we don't plan to do it in this Pull Request.
