### PR TITLE
Add type to calendar date button

### DIFF
--- a/src/js/Pickers/CalendarDate.js
+++ b/src/js/Pickers/CalendarDate.js
@@ -75,6 +75,7 @@ export default class CalendarDate extends PureComponent {
         style={{ display: 'inline-block' }}
       >
         <button
+          type="button"
           ref={this._setFocus}
           onFocus={this._setActive}
           onBlur={this._setInactive}


### PR DESCRIPTION
This fixes a bug where if the `CalendarDate` component is used inside of a form, clicking on the button submits the form, instead of selecting the date.