### PR TITLE
Add autoFocusAction prop to set focus automatically on action button in snackbar

### DIFF
--- a/docs/src/components/Components/Snackbars/Interactive.jsx
+++ b/docs/src/components/Components/Snackbars/Interactive.jsx
@@ -16,6 +16,7 @@ export default class Interactive extends PureComponent {
     action: '',
     autohide: true,
     autohideTimeout: Snackbar.defaultProps.autohideTimeout,
+    target: null,
   };
 
   handleSubmit = (e) => {
@@ -40,6 +41,7 @@ export default class Interactive extends PureComponent {
   dismiss = () => {
     const [, ...toasts] = this.state.toasts;
     this.setState({ toasts });
+    this.submitButton.focus();
   };
 
   updateText = (text) => {
@@ -116,6 +118,7 @@ export default class Interactive extends PureComponent {
             disabled={!text || !autohideTimeout}
             type="submit"
             className="md-btn--dialog md-cell--right"
+            ref={(c) => { this.submitButton = c; }}
           >
             Toast
           </Button>

--- a/src/js/Snackbars/Snackbar.js
+++ b/src/js/Snackbars/Snackbar.js
@@ -7,6 +7,7 @@ import isInvalidAnimate from './isInvalidAnimate';
 
 export default class Snackbar extends PureComponent {
   static propTypes = {
+    autoFocusAction: PropTypes.bool,
     id: PropTypes.oneOfType([
       PropTypes.number,
       PropTypes.string,
@@ -119,6 +120,7 @@ export default class Snackbar extends PureComponent {
 
   render() {
     const {
+      autoFocusAction,
       className,
       toast,
       multiline,
@@ -141,6 +143,7 @@ export default class Snackbar extends PureComponent {
       text = <p className="md-snackbar--toast md-snackbar--action">{text}</p>;
 
       let btnProps = {
+        autoFocus: autoFocusAction,
         flat: true,
         onClick: this._handleClick,
         children: action,

--- a/src/js/Snackbars/SnackbarContainer.js
+++ b/src/js/Snackbars/SnackbarContainer.js
@@ -23,6 +23,14 @@ const CHAINED_TOAST_DELAY = 50;
 export default class SnackbarContainer extends PureComponent {
   static propTypes = {
     /**
+     * When a toast has an action, it will automatically be focused when this prop is enabled.
+     * This will require your action onClick handler to correctly focus an element on the page
+     * once the toast is hidden. If this prop is disabled, it is recommended to add custom focus
+     * logic so that keyboard users can interact with the snackbar.
+     */
+    autoFocusAction: PropTypes.bool,
+
+    /**
      * An id for the Snackbar once a toast has been added and is visible. This is a recommended
      * prop for accessibility concerns. If it is omitted, the id will become `'snackbar-alert'`
      * when there is no action on the toast, or `'snackbar-alert-dialog'` when there is an action
@@ -165,6 +173,7 @@ export default class SnackbarContainer extends PureComponent {
   };
 
   static defaultProps = {
+    autoFocusAction: true,
     autohide: true,
     toasts: [],
     autohideTimeout: 3000,


### PR DESCRIPTION
This is another pass at https://github.com/mlaursen/react-md/pull/806 based off 1.7.x branch. It adds the autoFocusAction prop as described on that PR. It also modifies the interactive demo to show handling of focus on dismiss.

*Before* submitting a pull request, please make sure the following is done:

1. Fork the repo and create your branch from `release/MAJOR.MINOR.x`. At the time of creating this, react-md is at version v1.0.0, so you would branch off of `release/1.0.x`.
2. If you have added code that should be tested, please add tests.
3. If you have added new prop types or deprecated prop types, please update the docgen descriptions. When TypeScript is fully implemented, update the types as well.
4. Ensure that the test suite passes (`npm test`).
5. Ensure that your code lints (`npm run lint`).
  > NOTE: Sass changes rely on the Ruby version of `sass` and `scss-lint` to work.
  

6. If your pull request attempts to fix an existing issue, please reference that issue via a commit message or the pull request comment.
7. If this is a new feature or component that has a visual impact, please provide any screenshots or images.
