### PR TITLE
Added a new prop to turn off focusing of button that opens dialog.

### DIFF
--- a/src/js/Dialogs/DialogContainer.d.ts
+++ b/src/js/Dialogs/DialogContainer.d.ts
@@ -23,6 +23,7 @@ export interface DialogContainerProps extends DialogProps {
   renderNode?: Object;
   lastChild?: boolean;
   defaultVisibleTransitionable?: boolean;
+  activeElementFocus?: boolean;
 }
 
 declare const DialogContainer: React.ComponentClass<DialogContainerProps>;

--- a/src/js/Dialogs/DialogContainer.js
+++ b/src/js/Dialogs/DialogContainer.js
@@ -357,6 +357,11 @@ export default class DialogContainer extends PureComponent {
      */
     stackedActions: PropTypes.bool,
 
+    /**
+     * Boolean if the active element should be focused after closing the dialog.
+     */
+    activeElementFocus: PropTypes.bool,
+
     isOpen: deprecated(PropTypes.bool, 'Use `visible` instead'),
     transitionName: deprecated(PropTypes.string, 'The transition name will be managed by the component'),
     transitionEnter: deprecated(PropTypes.bool, 'The transition will always be enforced'),
@@ -376,6 +381,7 @@ export default class DialogContainer extends PureComponent {
     transitionEnterTimeout: 300,
     transitionLeaveTimeout: 300,
     defaultVisibleTransitionable: false,
+    activeElementFocus: true
   };
 
   static contextTypes = {
@@ -518,7 +524,7 @@ export default class DialogContainer extends PureComponent {
   _handleDialogMounting = (dialog) => {
     const { disableScrollLocking } = this.props;
     if (dialog === null) {
-      if (this._activeElement && this._activeElement.focus) {
+      if (this._activeElement && this._activeElement.focus && this.props.activeElementFocus) {
         this._activeElement.focus();
       }
 

--- a/src/js/Dialogs/DialogContainer.js
+++ b/src/js/Dialogs/DialogContainer.js
@@ -358,7 +358,9 @@ export default class DialogContainer extends PureComponent {
     stackedActions: PropTypes.bool,
 
     /**
-     * Boolean if the active element should be focused after closing the dialog.
+     * Boolean if the active element should be focused after closing the dialog. It is generally recommended to
+     * keep this enabled so that keyboard users do not lose their place within the application after a dialog is
+     * closed. When this is set to false, you should implement your own focus logic.
      */
     activeElementFocus: PropTypes.bool,
 
@@ -576,6 +578,7 @@ export default class DialogContainer extends PureComponent {
       onHide,
       disableScrollLocking,
       defaultVisibleTransitionable,
+      activeElementFocus,
 
       // deprecated
       close,

--- a/src/js/Dialogs/DialogContainer.js
+++ b/src/js/Dialogs/DialogContainer.js
@@ -381,7 +381,7 @@ export default class DialogContainer extends PureComponent {
     transitionEnterTimeout: 300,
     transitionLeaveTimeout: 300,
     defaultVisibleTransitionable: false,
-    activeElementFocus: true
+    activeElementFocus: true,
   };
 
   static contextTypes = {


### PR DESCRIPTION
We are using this component library for one of our projects (nice job, btw). We want to change the behavior of the DialogContainer such that it does not focus the element that triggers the dialog opening when it is closing. This PR adds a new prop for the DialogContainer to do just that. I didn't see any tests specific to props, so I didn't write any new ones. I can if you feel it's necessary, but the code is pretty minimal.
