### PR TITLE
Added componentRef prop to Paper and TabsContainer

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -64,7 +64,7 @@
     "marked": "^0.3.6",
     "mobile-detect": "^1.3.6",
     "morgan": "^1.9.0",
-    "node-sass": "^4.5.3",
+    "node-sass": "^4.12.0",
     "prismjs": "^1.10.0",
     "prop-types": "^15.6.0",
     "qs": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "gzip-size": "^4.0.0",
     "intl": "^1.2.5",
     "jest-cli": "^21.2.1",
-    "node-sass": "^4.5.3",
+    "node-sass": "^4.12.0",
     "npm-run-all": "^4.1.1",
     "postcss": "^6.0.13",
     "pretty-bytes": "^4.0.2",

--- a/src/js/Papers/Paper.d.ts
+++ b/src/js/Papers/Paper.d.ts
@@ -6,6 +6,7 @@ export interface PaperProps extends Props {
   [key: string]: any;
 
   component?: React.ReactType;
+  componentRef?: (ref: React.ReactHTMLElement<any> | null) => null;
   children?: React.ReactNode;
   zDepth?: number;
   raiseOnHover?: boolean;

--- a/src/js/Papers/Paper.d.ts
+++ b/src/js/Papers/Paper.d.ts
@@ -6,7 +6,7 @@ export interface PaperProps extends Props {
   [key: string]: any;
 
   component?: React.ReactType;
-  componentRef?: (ref: React.ReactHTMLElement<any> | null) => null;
+  componentRef?: React.Ref<any>;
   children?: React.ReactNode;
   zDepth?: number;
   raiseOnHover?: boolean;

--- a/src/js/Papers/Paper.js
+++ b/src/js/Papers/Paper.js
@@ -25,6 +25,15 @@ export default class Paper extends PureComponent {
     ]).isRequired,
 
     /**
+     * An optional ref callback to get reference to the top-most element of the rendered component.
+     * Just like other refs, this will provide null when it unmounts.
+     *
+     * This is helpful if you'd like access the DOM node for a parent Component without needing to use
+     * `ReactDOM.findDOMNode`.
+     */
+    componentRef: PropTypes.func,
+
+    /**
      * An optional className to apply.
      */
     className: PropTypes.string,
@@ -53,11 +62,12 @@ export default class Paper extends PureComponent {
   };
 
   render() {
-    const { component: Component, zDepth, className, raiseOnHover, ...props } = this.props;
+    const { component: Component, componentRef, zDepth, className, raiseOnHover, ...props } = this.props;
 
     return (
       <Component
         {...props}
+        ref={componentRef}
         className={cn(`md-paper md-paper--${zDepth}`, {
           'md-paper--0-hover': zDepth === 0 && raiseOnHover,
         }, className)}

--- a/src/js/Papers/Paper.js
+++ b/src/js/Papers/Paper.js
@@ -31,7 +31,10 @@ export default class Paper extends PureComponent {
      * This is helpful if you'd like access the DOM node for a parent Component without needing to use
      * `ReactDOM.findDOMNode`.
      */
-    componentRef: PropTypes.func,
+    componentRef: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.object,
+    ]),
 
     /**
      * An optional className to apply.

--- a/src/js/Papers/__tests__/Paper.js
+++ b/src/js/Papers/__tests__/Paper.js
@@ -20,4 +20,17 @@ describe('Paper', () => {
     expect(paperNode.style.background).toBe(props.style.background);
     expect(paperNode.className).toContain(props.className);
   });
+
+  it('should provide reference to component', () => {
+    let componentRef;
+    const props = {
+      component: 'p',
+      componentRef: (ref) => { componentRef = ref; },
+      zDepth: 2,
+    };
+    renderIntoDocument(<Paper {...props} />);
+
+    expect(componentRef.nodeName).toBe('P');
+    expect(componentRef.classList.contains('md-paper--2')).toBe(true);
+  });
 });

--- a/src/js/Tabs/TabsContainer.d.ts
+++ b/src/js/Tabs/TabsContainer.d.ts
@@ -16,7 +16,7 @@ export interface TabsContainerProps extends Props {
   slideClassName?: string;
   children?: React.ReactElement<Tabs>,
   component?: React.ReactType;
-  componentRef?: (ref: React.ReactHTMLElement<any> | null) => null;
+  componentRef?: React.Ref<any>;
   panelComponent?: React.ReactType;
   headerComponent?: React.ReactType;
   toolbar?: React.ReactElement<any>;

--- a/src/js/Tabs/TabsContainer.d.ts
+++ b/src/js/Tabs/TabsContainer.d.ts
@@ -16,6 +16,7 @@ export interface TabsContainerProps extends Props {
   slideClassName?: string;
   children?: React.ReactElement<Tabs>,
   component?: React.ReactType;
+  componentRef?: (ref: React.ReactHTMLElement<any> | null) => null;
   panelComponent?: React.ReactType;
   headerComponent?: React.ReactType;
   toolbar?: React.ReactElement<any>;

--- a/src/js/Tabs/TabsContainer.js
+++ b/src/js/Tabs/TabsContainer.js
@@ -126,7 +126,10 @@ export default class TabsContainer extends PureComponent {
      * This is helpful if you'd like access the DOM node for a parent Component without needing to use
      * `ReactDOM.findDOMNode`.
      */
-    componentRef: PropTypes.func,
+    componentRef: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.object,
+    ]),
 
     /**
      * The component to render each `TabPanel` as.
@@ -261,7 +264,13 @@ export default class TabsContainer extends PureComponent {
     const { componentRef } = this.props;
     this._container = findDOMNode(container);
     if (componentRef) {
-      componentRef(this._container);
+      const refType = typeof componentRef;
+      if (refType === 'function') {
+        componentRef(this._container);
+      }
+      else if (refType === 'object') {
+        componentRef.current = this._container;
+      }
     }
   };
 

--- a/src/js/Tabs/TabsContainer.js
+++ b/src/js/Tabs/TabsContainer.js
@@ -120,6 +120,15 @@ export default class TabsContainer extends PureComponent {
     ]).isRequired,
 
     /**
+     * An optional ref callback to get reference to the top-most element of the rendered container.
+     * Just like other refs, this will provide null when it unmounts.
+     *
+     * This is helpful if you'd like access the DOM node for a parent Component without needing to use
+     * `ReactDOM.findDOMNode`.
+     */
+    componentRef: PropTypes.func,
+
+    /**
      * The component to render each `TabPanel` as.
      */
     panelComponent: PropTypes.oneOfType([
@@ -249,7 +258,11 @@ export default class TabsContainer extends PureComponent {
   };
 
   _setContainer = (container) => {
+    const { componentRef } = this.props;
     this._container = findDOMNode(container);
+    if (componentRef) {
+      componentRef(this._container);
+    }
   };
 
   _resizePanel = () => {
@@ -291,6 +304,7 @@ export default class TabsContainer extends PureComponent {
       activeTabIndex: propActiveTabeIndex,
       onTabChange,
       defaultTabIndex,
+      componentRef,
       /* eslint-enable no-unused-vars */
       ...props
     } = this.props;


### PR DESCRIPTION
Hello,

I've added `componentRef` prop to `Paper` and `TabsContainer` to have ability to expose DOM refs to parent components.