### PR TITLE
added aria-hidden to FontIcon <i> element

### DIFF
--- a/src/js/FontIcons/FontIcon.js
+++ b/src/js/FontIcons/FontIcon.js
@@ -163,7 +163,7 @@ export default class FontIcon extends PureComponent {
     }), className);
 
     return (
-      <i {...props} style={styles} className={classes}>
+      <i {...props} style={styles} className={classes} aria-hidden="true">
         {children}
       </i>
     );


### PR DESCRIPTION
The company I work at is requesting that we add a `aria-hidden` attribute to this icon because it is causing accessibility issues with the sorting of the `DataTable` component. The sorting of the table is already being read by the screen reader, but the screen reader is reading the name of the icon as well and we would like to hide it with aria. Please let me know if you have any questions or other ideas about how we could accomplish this.  Thank you!
