### PR TITLE
replace `AccessibleFakeInkButton` with `AccessibleFakeInkedButton`

### DIFF
--- a/docs/src/components/Components/Helpers/AccessibleFakeButtons/README.md
+++ b/docs/src/components/Components/Helpers/AccessibleFakeButtons/README.md
@@ -4,4 +4,4 @@ attributes to any html tag or React component for accessibility.
 The button will be able to be focused via normal tab behavior, update it's role to be a `button`
 when it is not rendered as a link, and keep an `aria-pressed` state up to date.
 
-There is also an `AccessibleFakeInkButton` if you want to use ink with the button.
+There is also an `AccessibleFakeInkedButton` if you want to use ink with the button.

--- a/src/js/SelectionControls/SwitchThumb.js
+++ b/src/js/SelectionControls/SwitchThumb.js
@@ -9,7 +9,7 @@ const DISABLED_INTERACTIONS = ['mouse'];
 
 /**
  * This is the `Thumb` for the switch. The `ink` in the Thumb is only active on touch and keyboard
- * interactions, so the `AccessibleFakeInkButton` does not work for this case.
+ * interactions, so the `AccessibleFakeInkedButton` does not work for this case.
  *
  * This component really just is used for custom inkage.
  */


### PR DESCRIPTION
It's just a typo in the documentation I noticed when trying to use AccessibleFakeInkedButton.

Performed a find and replace on the whole project. 