### PR TITLE
Added saveListScrollTop and listScrollTopUpdate props to SelectField

### DIFF
--- a/docs/src/components/Components/SelectFields/Simple.jsx
+++ b/docs/src/components/Components/SelectFields/Simple.jsx
@@ -29,6 +29,10 @@ function getActiveLabel({ activeLabel, activeIndex }) {
   return activeIndex > -1 ? `#${activeIndex + 1}: ${activeLabel}` : activeLabel;
 }
 
+function listScrollTopUpdate({ activeItemNode }) {
+  return activeItemNode.offsetHeight;
+}
+
 const Simple = ({ simplifiedMenu }) => (
   <div className="md-grid">
     <h4 className="md-cell md-cell--12">Normal SelectFields</h4>
@@ -63,6 +67,24 @@ const Simple = ({ simplifiedMenu }) => (
       className="md-cell"
       menuItems={OBJECT_ITEMS}
       getActiveLabel={getActiveLabel}
+      simplifiedMenu={simplifiedMenu}
+    />
+    <SelectField
+      id="select-field-3-2"
+      label="Preserve List's Scroll Top Position"
+      placeholder="Placeholder"
+      className="md-cell"
+      menuItems={STRING_ITEMS}
+      saveListScrollTop
+      simplifiedMenu={simplifiedMenu}
+    />
+    <SelectField
+      id="select-field-3-3"
+      label="Change Active Item's Visible Position in List"
+      placeholder="Placeholder"
+      className="md-cell"
+      menuItems={STRING_ITEMS}
+      listScrollTopUpdate={listScrollTopUpdate}
       simplifiedMenu={simplifiedMenu}
     />
     <h4 className="md-cell md-cell--12">SelectField Buttons</h4>

--- a/src/js/Lists/List.d.ts
+++ b/src/js/Lists/List.d.ts
@@ -6,5 +6,8 @@ export interface ListProps extends Props {
   ordered?: boolean;
 }
 
-declare const List: React.ComponentClass<ListProps>;
+export interface ListComponent extends React.ComponentClass<ListProps> {
+}
+
+declare const List: ListComponent;
 export default List;

--- a/src/js/SelectFields/SelectField.d.ts
+++ b/src/js/SelectFields/SelectField.d.ts
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import { IdPropType, Props } from '../index';
+import { ListComponent } from '../Lists/List';
+import { ListItemComponent } from '../Lists/ListItem';
 import { SharedTextFieldProps } from '../TextFields';
 
 import {
@@ -35,6 +37,18 @@ export interface GetActiveLabelParam {
   field: SelectFieldComponent;
 }
 
+export interface ListScrollTopUpdateParam {
+  listRef: ListComponent;
+  listNode: HTMLElement;
+  listScrollTop: number;
+  newListScrollTop: number;
+  listItems: ListItemComponent[];
+  activeItemRef: ListItemComponent;
+  activeItemNode: HTMLElement;
+  activeIndex: number;
+  field: SelectFieldComponent;
+}
+
 export interface FieldDataProps {
   id: string;
   name: string;
@@ -60,6 +74,8 @@ export interface SharedSelectFieldProps extends BaseMenuProps, SharedTextFieldPr
   name?: string;
   getItemProps?: (data: GetItemPropsParam) => Object;
   getActiveLabel?: (data: GetActiveLabelParam) => React.ReactNode;
+  saveListScrollTop?: boolean;
+  listScrollTopUpdate?: number | ((data: ListScrollTopUpdateParam) => number);
   defaultValue?: ListValue;
   value?: ListValue;
   onChange?: (value: ListValue, selectedIndex: number, event: React.MouseEvent<HTMLElement>, data: FieldDataProps) => void;

--- a/src/js/SelectFields/__tests__/SelectField.js
+++ b/src/js/SelectFields/__tests__/SelectField.js
@@ -290,4 +290,48 @@ describe('SelectField', () => {
     label = field.find(FloatingLabel);
     expect(label.props().floating).toBe(true);
   });
+
+  it('should call function to change list\'s scrollTop', () => {
+    const listScrollTopUpdate = jest.fn(() => 48);
+    const field = mount(
+      <SelectField
+        id="test"
+        menuItems={['a', 'b', 'c', 'd', 'e']}
+        value="c"
+        listScrollTopUpdate={listScrollTopUpdate}
+        onChange={jest.fn()}
+        onVisibilityChange={jest.fn()}
+      />
+    );
+
+    const calls = listScrollTopUpdate.mock.calls;
+    expect(calls.length).toBe(0);
+
+    field.setProps({ visible: true });
+    expect(calls.length).toBe(1);
+    expect(calls[0].length).toBe(1);
+    expect(typeof calls[0][0]).toBe('object');
+    expect(calls[0][0]).not.toBeNull();
+  });
+
+  it('should not call function to change list\'s scrollTop', () => {
+    const listScrollTopUpdate = jest.fn(() => 48);
+    const field = mount(
+      <SelectField
+        id="test"
+        menuItems={['a', 'b', 'c', 'd', 'e']}
+        value="c"
+        saveListScrollTop
+        listScrollTopUpdate={listScrollTopUpdate}
+        onChange={jest.fn()}
+        onVisibilityChange={jest.fn()}
+      />
+    );
+
+    const calls = listScrollTopUpdate.mock.calls;
+    expect(calls.length).toBe(0);
+
+    field.setProps({ visible: true });
+    expect(calls.length).toBe(0);
+  });
 });


### PR DESCRIPTION
Hello,

I've added `saveListScrollTop` and `listScrollTopUpdate` props into `SelectField` to have ability to control active item's position inside dropdown list.