### PR TITLE
Improve accessibility of the Datepicker component

### DIFF
--- a/src/js/Pickers/CalendarHeader.js
+++ b/src/js/Pickers/CalendarHeader.js
@@ -129,14 +129,18 @@ export default class CalendarHeader extends PureComponent {
             disabled={isPreviousDisabled}
             className="md-calendar-control"
             iconEl={previousIcon}
+            aria-label="Previous Month"
           />
-          <h4 className={cn('md-title', titleClassName)}>{title}</h4>
+          <h4 className={cn('md-title', titleClassName)} aria-live="polite">
+            {title}
+          </h4>
           <Button
             icon
             onClick={onNextClick}
             disabled={isNextDisabled}
             className="md-calendar-control"
             iconEl={nextIcon}
+            aria-label="Next Month"
           />
         </div>
         <div className="md-calendar-dows">

--- a/src/js/Pickers/CalendarHeader.js
+++ b/src/js/Pickers/CalendarHeader.js
@@ -24,6 +24,8 @@ export default class CalendarHeader extends PureComponent {
     previousIcon: PropTypes.element,
     onPreviousClick: PropTypes.func.isRequired,
     nextIcon: PropTypes.node,
+    previousMonthLabel: PropTypes.string,
+    nextMonthLabel: PropTypes.string,
     onNextClick: PropTypes.func.isRequired,
     DateTimeFormat: PropTypes.func.isRequired,
     locales: PropTypes.oneOfType([
@@ -116,6 +118,8 @@ export default class CalendarHeader extends PureComponent {
       onNextClick,
       nextIcon,
       titleClassName,
+      previousMonthLabel,
+      nextMonthLabel,
     } = this.props;
 
     const isPreviousDisabled = isMonthBefore(minDate, date);
@@ -129,7 +133,7 @@ export default class CalendarHeader extends PureComponent {
             disabled={isPreviousDisabled}
             className="md-calendar-control"
             iconEl={previousIcon}
-            aria-label="Previous Month"
+            aria-label={previousMonthLabel}
           />
           <h4 className={cn('md-title', titleClassName)} aria-live="polite">
             {title}
@@ -140,7 +144,7 @@ export default class CalendarHeader extends PureComponent {
             disabled={isNextDisabled}
             className="md-calendar-control"
             iconEl={nextIcon}
-            aria-label="Next Month"
+            aria-label={nextMonthLabel}
           />
         </div>
         <div className="md-calendar-dows">

--- a/src/js/Pickers/DatePickerCalendar.js
+++ b/src/js/Pickers/DatePickerCalendar.js
@@ -11,6 +11,8 @@ export default class DatePickerCalendar extends PureComponent {
     previousIcon: PropTypes.element,
     onPreviousClick: PropTypes.func.isRequired,
     nextIcon: PropTypes.element,
+    previousMonthLabel: PropTypes.string,
+    nextMonthLabel: PropTypes.string,
     onNextClick: PropTypes.func.isRequired,
     onCalendarDateClick: PropTypes.func.isRequired,
     calendarDate: PropTypes.instanceOf(Date).isRequired,
@@ -90,6 +92,8 @@ export default class DatePickerCalendar extends PureComponent {
       previousIcon,
       onPreviousClick,
       nextIcon,
+      previousMonthLabel,
+      nextMonthLabel,
       onNextClick,
       calendarDate,
       calendarTempDate,
@@ -124,6 +128,8 @@ export default class DatePickerCalendar extends PureComponent {
           previousIcon={previousIcon}
           onNextClick={onNextClick}
           nextIcon={nextIcon}
+          previousMonthLabel={previousMonthLabel}
+          nextMonthLabel={nextMonthLabel}
           firstDayOfWeek={firstDayOfWeek}
           titleClassName={titleClassName}
           titleFormat={titleFormat}

--- a/src/js/Pickers/DatePickerContainer.d.ts
+++ b/src/js/Pickers/DatePickerContainer.d.ts
@@ -13,6 +13,8 @@ export interface DatePickerProps extends BasePickerProps {
   defaultCalendarDate?: string | Date;
   nextIcon?: React.ReactElement<any>;
   previousIcon?: React.ReactElement<any>;
+  previousMonthLabel?: string;
+  nextMonthLabel?: string;
   firstDayOfWeek?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
   calendarClassName?: string;
   yearPickerClassName?: string;

--- a/src/js/Pickers/DatePickerContainer.js
+++ b/src/js/Pickers/DatePickerContainer.js
@@ -542,6 +542,16 @@ export default class DatePickerContainer extends PureComponent {
     disableScrollLocking: PropTypes.bool,
 
     /**
+     * The label to use for the previous month button on the date picker.
+     */
+    previousMonthLabel: PropTypes.string,
+
+    /**
+     * The label to use for the next month button on the date picker.
+     */
+    nextMonthLabel: PropTypes.string,
+
+    /**
      * Boolean if the dialog should be rendered as the last child of the `renderNode` or `body` instead
      * of the first.
      */
@@ -590,6 +600,8 @@ export default class DatePickerContainer extends PureComponent {
     closeOnEsc: true,
     closeYearOnSelect: false,
     disableScrollLocking: false,
+    previousMonthLabel: 'Previous Month',
+    nextMonthLabel: 'Next Month',
     'aria-label': 'Pick a date',
   };
 


### PR DESCRIPTION
In the Datepicker component, the Previous Month and Next Month buttons are unlabeled using a screen reader and there is no notification that the date picker has moved to the next or previous month unless the user navigates to the Month Header.

Proposed fixes:
- add aria-labels to next/previous month buttons
- add aria-live tag to the current month so changes are announced to screenreaders