### PR TITLE
Release/v2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,9 @@ estimated size for this library, check out the results below:
 $ yarn dev-utils libsize
 
 The gzipped UMD bundle size is:
- - dist/umd/react-md.production.min.js 202.95 KB
+ - dist/umd/react-md.production.min.js 86.49 KB
+ - dist/umd/react-md.font-icon.production.min.js 106.77 KB
+ - dist/umd/react-md.svg-icon.production.min.js 116.86 KB
 
 The min and max gzipped CSS bundle sizes are:
  - dist/css/react-md.grey-deep_orange-200-light.min.css 15.65 KB

--- a/README.md
+++ b/README.md
@@ -181,11 +181,11 @@ estimated size for this library, check out the results below:
 $ yarn dev-utils libsize
 
 The gzipped UMD bundle size is:
- - dist/umd/react-md.production.min.js 55 B
+ - dist/umd/react-md.production.min.js 202.95 KB
 
 The min and max gzipped CSS bundle sizes are:
- - dist/css/react-md.red-lime-100-light.min.css 61 B
- - dist/css/react-md.deep_orange-blue_grey-100-light.min.css 76 B
+ - dist/css/react-md.grey-deep_orange-200-light.min.css 15.65 KB
+ - dist/css/react-md.indigo-blue-400-dark.min.css 15.71 KB
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -180,10 +180,11 @@ estimated size for this library, check out the results below:
 ```sh
 $ yarn dev-utils libsize
 
-The gzipped UMD bundle size is:
+The gzipped UMD bundle sizes are:
  - dist/umd/react-md.production.min.js 86.49 KB
- - dist/umd/react-md.font-icon.production.min.js 106.77 KB
- - dist/umd/react-md.svg-icon.production.min.js 116.86 KB
+ - dist/umd/react-md-with-font-icons.production.min.js 186.23 KB
+ - dist/umd/react-md-with-svg-icons.production.min.js 196.03 KB
+
 
 The min and max gzipped CSS bundle sizes are:
  - dist/css/react-md.grey-deep_orange-200-light.min.css 15.65 KB

--- a/packages/dev-utils/src/libsize.ts
+++ b/packages/dev-utils/src/libsize.ts
@@ -1,5 +1,6 @@
 import { execSync } from "child_process";
 import filesize from "filesize";
+import { readFileSync } from "fs";
 import gzipSize from "gzip-size";
 import log from "loglevel";
 import { join } from "path";
@@ -34,7 +35,16 @@ async function umdSize(): Promise<void> {
   }
 
   log.info("The gzipped UMD bundle size is:");
-  log.info(list(umd.map((name) => `${name} ${filesize(gzipSize.sync(name))}`)));
+  log.info(
+    list(
+      umd.map(
+        (name) =>
+          `${name} ${filesize(
+            gzipSize.sync(readFileSync(join(cwd, name), "utf8"))
+          )}`
+      )
+    )
+  );
   log.info();
 }
 
@@ -50,7 +60,7 @@ async function cssSize(): Promise<void> {
 
   const { min, max } = css.reduce(
     (result, cssPath) => {
-      const size = gzipSize.sync(cssPath);
+      const size = gzipSize.sync(readFileSync(join(cwd, cssPath), "utf8"));
       const update = { name: cssPath, size };
       if (size > result.max.size) {
         result.max = update;

--- a/packages/dev-utils/src/libsize.ts
+++ b/packages/dev-utils/src/libsize.ts
@@ -46,7 +46,7 @@ async function createUmd(): Promise<void> {
   log.info("Creating the UMD bundles...");
   const cwd = join(packagesRoot, "material-icons", "src");
   const svgs = await glob("*SVGIcon.tsx", { cwd });
-  const fonts = await glob("*.FontIcon.tsx", { cwd });
+  const fonts = await glob("*FontIcon.tsx", { cwd });
   const reactMDSrc = join(packagesRoot, "react-md", "src");
   const mainBundlePath = join(reactMDSrc, "rollup.ts");
   const svgBundlePath = join(reactMDSrc, "svg.ts");

--- a/packages/documentation/src/blogs/index.md
+++ b/packages/documentation/src/blogs/index.md
@@ -14,13 +14,13 @@ react-md will now be available as these bundles:
 
 1. Base `ReactMD` library:<br />
    https://unpkg.com/react-md@2.0.1/dist/umd/react-md.production.min.js
-1. `ReactMDIconFont` components:<br />
-   https://unpkg.com/react-md@2.0.1/dist/umd/react-md.font-icon.production.min.js
-1. `ReactMDIconSVG` components:<br />
-   https://unpkg.com/react-md@2.0.1/dist/umd/react-md.svg-icon.production.min.js
+1. `ReactMD` with `*FontIcon` components:<br />
+   https://unpkg.com/react-md@2.0.1/dist/umd/react-md-with-font-icons.production.min.js
+1. `ReactMD` with `*SVGIcon` components:<br />
+   https://unpkg.com/react-md@2.0.1/dist/umd/react-md-with-svg-icons.production.min.js
 
 The
-[advanced installation guide](/guides/advanced-installation#using-the-cdn-hosted-material-icon-components)
+[advanced installation guide](/guides/advanced-installation#react-md--material-icons-umd-bundle)
 and the [library size notes](/about#what39s-the-library-size) have been updated
 for this information.
 

--- a/packages/documentation/src/blogs/index.md
+++ b/packages/documentation/src/blogs/index.md
@@ -1,3 +1,31 @@
+Title: react-md 2.0.1
+
+Date: 06/17/2020
+
+Summary:
+
+This is _technically_ a breaking change for the UMD bundle since this splits the
+material-icon component wrappers into separate bundles to minimize the library's
+size. I'm going with a patch bump though since it's only been two days since the
+v2 release and it's highly doubtful that consumers of the library have fully
+upgraded to v2 or even using the UMD bundle to begin with.
+
+react-md will now be available as these bundles:
+
+1. Base `ReactMD` library:<br />
+   https://unpkg.com/react-md@2.0.1/dist/umd/react-md.production.min.js
+1. `ReactMDIconFont` components:<br />
+   https://unpkg.com/react-md@2.0.1/dist/umd/react-md.font-icon.production.min.js
+1. `ReactMDIconSVG` components:<br />
+   https://unpkg.com/react-md@2.0.1/dist/umd/react-md.svg-icon.production.min.js
+
+The
+[advanced installation guide](/guides/advanced-installation#using-the-cdn-hosted-material-icon-components)
+and the [library size notes](/about#what39s-the-library-size) have been updated
+for this information.
+
+---
+
 Title: react-md 2.0.0
 
 Date: 06/15/2020

--- a/packages/documentation/src/blogs/v2-release.md
+++ b/packages/documentation/src/blogs/v2-release.md
@@ -568,8 +568,8 @@ The min and max gzipped CSS bundle sizes are:
 v2 size
 The gzipped UMD bundle size is:
  - dist/umd/react-md.production.min.js 86.49 KB
- - dist/umd/react-md.font-icon.production.min.js 106.77 KB
- - dist/umd/react-md.svg-icon.production.min.js 116.86 KB
+ - dist/umd/react-md-with-font-icons.production.min.js 186.23 KB
+ - dist/umd/react-md-with-svg-icons.production.min.js 196.03 KB
 
 The min and max gzipped CSS bundle sizes are:
  - dist/css/react-md.grey-deep_orange-200-light.min.css 15.65 KB

--- a/packages/documentation/src/blogs/v2-release.md
+++ b/packages/documentation/src/blogs/v2-release.md
@@ -553,26 +553,29 @@ has been helpful and what has not.
 
 ### GZip Size Comparison
 
-There was a slight size increase with the v2 release now that a lot more
-functionality and components have been added. The UMD size has increased by
-`~17%` and the CSS bundles have increased by `~7% - 9%`:
+Due to including the new 1800+ material icons in the UMD bundle by default, the
+UMD size has increased by `105.66%` while the CSS bundles have increased by
+`18.56% - 18.75%`:
+
+> The gzip size of the new UMD bundle without all the material icons is actually
+> `86.49 KB` which is a **12.35% decrease** in size.
 
 ```sh
-v2 size
-The gzipped UMD bundle size is:
- - dist/umd/react-md.production.min.js 55 B
-
-The min and max gzipped CSS bundle sizes are:
- - dist/css/react-md.red-lime-100-light.min.css 61 B
- - dist/css/react-md.blue_grey-deep_orange-100-light.min.css 76 B
-
 v1 size
 The gzipped UMD bundle size is:
- - v1/dist/umd/react-md.min.js 47 B
+ - dist/v1/umd/react-md.min.js 98.68 KB
 
 The min and max gzipped CSS bundle sizes are:
- - v1/dist/css/react-md.blue-red.min.css 56 B
- - v1/dist/css/react-md.deep_orange-light_green.min.css 71 B
+ - dist/v1/css/react-md.yellow-red.min.css 13.2 KB
+ - dist/v1/css/react-md.blue_grey-deep_purple.min.css 13.23 KB
+
+v2 size
+The gzipped UMD bundle size is:
+ - dist/umd/react-md.production.min.js 202.95 KB
+
+The min and max gzipped CSS bundle sizes are:
+ - dist/css/react-md.grey-deep_orange-200-light.min.css 15.65 KB
+ - dist/css/react-md.indigo-blue-400-dark.min.css 15.71 KB
 ```
 
 That being said, v2 _should_ have finally solved the code splitting issue that

--- a/packages/documentation/src/blogs/v2-release.md
+++ b/packages/documentation/src/blogs/v2-release.md
@@ -553,12 +553,8 @@ has been helpful and what has not.
 
 ### GZip Size Comparison
 
-Due to including the new 1800+ material icons in the UMD bundle by default, the
-UMD size has increased by `105.66%` while the CSS bundles have increased by
-`18.56% - 18.75%`:
-
-> The gzip size of the new UMD bundle without all the material icons is actually
-> `86.49 KB` which is a **12.35% decrease** in size.
+The v2 release has decreased the UMD bundle size by `12.35%` while the CSS
+bundles have increased by `18.56% - 18.75%`:
 
 ```sh
 v1 size
@@ -571,16 +567,18 @@ The min and max gzipped CSS bundle sizes are:
 
 v2 size
 The gzipped UMD bundle size is:
- - dist/umd/react-md.production.min.js 202.95 KB
+ - dist/umd/react-md.production.min.js 86.49 KB
+ - dist/umd/react-md.font-icon.production.min.js 106.77 KB
+ - dist/umd/react-md.svg-icon.production.min.js 116.86 KB
 
 The min and max gzipped CSS bundle sizes are:
  - dist/css/react-md.grey-deep_orange-200-light.min.css 15.65 KB
  - dist/css/react-md.indigo-blue-400-dark.min.css 15.71 KB
 ```
 
-That being said, v2 _should_ have finally solved the code splitting issue that
-existing in v1 and produce a smaller bundle if every feature within `react-md`
-is not used.
+In addition, v2 _should_ have finally solved the code splitting issue that
+existing in v1 and produce an even smaller bundle if every feature within
+`react-md` is not used.
 
 ## In-depth Changelogs
 

--- a/packages/documentation/src/components/About/README.md
+++ b/packages/documentation/src/components/About/README.md
@@ -20,7 +20,9 @@ estimated size for this library, check out the results below:
 $ yarn dev-utils libsize
 
 The gzipped UMD bundle size is:
- - dist/umd/react-md.production.min.js 202.95 KB
+ - dist/umd/react-md.production.min.js 86.49 KB
+ - dist/umd/react-md.font-icon.production.min.js 106.77 KB
+ - dist/umd/react-md.svg-icon.production.min.js 116.86 KB
 
 The min and max gzipped CSS bundle sizes are:
  - dist/css/react-md.grey-deep_orange-200-light.min.css 15.65 KB

--- a/packages/documentation/src/components/About/README.md
+++ b/packages/documentation/src/components/About/README.md
@@ -19,10 +19,11 @@ estimated size for this library, check out the results below:
 ```sh
 $ yarn dev-utils libsize
 
-The gzipped UMD bundle size is:
+The gzipped UMD bundle sizes are:
  - dist/umd/react-md.production.min.js 86.49 KB
- - dist/umd/react-md.font-icon.production.min.js 106.77 KB
- - dist/umd/react-md.svg-icon.production.min.js 116.86 KB
+ - dist/umd/react-md-with-font-icons.production.min.js 186.23 KB
+ - dist/umd/react-md-with-svg-icons.production.min.js 196.03 KB
+
 
 The min and max gzipped CSS bundle sizes are:
  - dist/css/react-md.grey-deep_orange-200-light.min.css 15.65 KB

--- a/packages/documentation/src/components/About/README.md
+++ b/packages/documentation/src/components/About/README.md
@@ -20,11 +20,11 @@ estimated size for this library, check out the results below:
 $ yarn dev-utils libsize
 
 The gzipped UMD bundle size is:
- - dist/umd/react-md.production.min.js 55 B
+ - dist/umd/react-md.production.min.js 202.95 KB
 
 The min and max gzipped CSS bundle sizes are:
- - dist/css/react-md.red-lime-100-light.min.css 61 B
- - dist/css/react-md.deep_orange-blue_grey-100-light.min.css 76 B
+ - dist/css/react-md.grey-deep_orange-200-light.min.css 15.65 KB
+ - dist/css/react-md.indigo-blue-400-dark.min.css 15.71 KB
 ```
 
 ## What are the supported browsers?

--- a/packages/documentation/src/components/Blog/Post.tsx
+++ b/packages/documentation/src/components/Blog/Post.tsx
@@ -46,7 +46,8 @@ const Post: FC<PostProps> = ({
         <Text color="secondary" type="body-2" component="p" margin="bottom">
           <RelativeDate date={date} />
         </Text>
-        <Markdown>{summary}</Markdown>
+        {/* hackily converts "lists" into bulleted lists without it be converted to the bullets part of a post */}
+        <Markdown>{summary.replace(/^1. /gm, "- ")}</Markdown>
         {bullets.length > 0 && (
           <Text component="ul" type="subtitle-1">
             {bullets.map((bullet) => {

--- a/packages/documentation/src/components/Home/LibraryInfo/OtherPros.tsx
+++ b/packages/documentation/src/components/Home/LibraryInfo/OtherPros.tsx
@@ -32,12 +32,12 @@ const OtherPros = (): ReactElement | null => (
         <li>
           Production UMD Bundle:
           <br />
-          <b>55 bytes</b>
+          <b>202.95 KB</b>
         </li>
         <li>
           Default Production CSS Bundles:
           <br />
-          <b>61 bytes</b> - <b>76 bytes</b>
+          <b>15.65 KB</b> - <b>15.71</b>
         </li>
       </ul>
     </li>

--- a/packages/documentation/src/components/Home/LibraryInfo/OtherPros.tsx
+++ b/packages/documentation/src/components/Home/LibraryInfo/OtherPros.tsx
@@ -1,43 +1,21 @@
 import React, { ReactElement } from "react";
 
-import Link from "components/Link";
-
-import { UNPKG } from "./constants";
 import TableCellList from "./TableCellList";
 
 const OtherPros = (): ReactElement | null => (
   <TableCellList>
-    <li>
-      UMD bundles available for both development and production through the
-      unpkg CDN.
-      <ul>
-        <li>
-          Development:
-          <br />
-          <Link href={`${UNPKG}/umd/react-md.development.js`}>
-            {`${UNPKG}/umd/react-md.development.js`}
-          </Link>
-        </li>
-        <li>
-          Production: <br />
-          <Link href={`${UNPKG}/umd/react-md.production.min.js`}>
-            {`${UNPKG}/umd/react-md.production.min.js`}
-          </Link>
-        </li>
-      </ul>
-    </li>
     <li>
       A fairly small library size (gzipped):
       <ul>
         <li>
           Production UMD Bundle:
           <br />
-          <b>202.95 KB</b>
+          <b>86.49 KB</b>
         </li>
         <li>
           Default Production CSS Bundles:
           <br />
-          <b>15.65 KB</b> - <b>15.71</b>
+          <b>15.65 KB</b> - <b>15.71 KB</b>
         </li>
       </ul>
     </li>

--- a/packages/documentation/src/constants/meta/tocs.ts
+++ b/packages/documentation/src/constants/meta/tocs.ts
@@ -184,8 +184,8 @@ const tocs: TOCRecord = {
       title: "Using the CDN hosted UMD bundle of react-md",
     },
     {
-      anchor: "#using-the-cdn-hosted-material-icon-components",
-      title: "Using the CDN hosted Material Icon Components",
+      anchor: "#react-md--material-icons-umd-bundle",
+      title: "react-md + Material Icons UMD Bundle",
     },
     {
       anchor: "#using-the-cdn-hosted-pre-compiled-themes",

--- a/packages/documentation/src/constants/meta/tocs.ts
+++ b/packages/documentation/src/constants/meta/tocs.ts
@@ -184,6 +184,10 @@ const tocs: TOCRecord = {
       title: "Using the CDN hosted UMD bundle of react-md",
     },
     {
+      anchor: "#using-the-cdn-hosted-material-icon-components",
+      title: "Using the CDN hosted Material Icon Components",
+    },
+    {
       anchor: "#using-the-cdn-hosted-pre-compiled-themes",
       title: "Using the CDN hosted pre-compiled themes",
     },

--- a/packages/documentation/src/guides/advanced-installation.md
+++ b/packages/documentation/src/guides/advanced-installation.md
@@ -54,45 +54,24 @@ To use the UMD bundle, you'll want to add a new `<script>` tag to your
 This _can_ be used with a custom webpack configuration as well, but requires a
 bit more work. Check out the documentation on [configuring externals].
 
-#### Using the CDN hosted Material Icon Components
+#### react-md + Material Icons UMD Bundle
 
 Since you'll normally only ever want to include either SVG icons or Font icons,
-the icon components have been separated into two separate bundles and can be
-referenced as `ReactMDIconFont` or `ReactMDIconSVG`.
-
-```ts
-import { TvFontIcon } from "react-md";
-```
-
-Would be the same as:
-
-```ts
-const { TvFontIcon } = ReactMDIconSVG;
-```
-
-Or with svg icons:
-
-```ts
-import { TvSVGIcon } from "react-md";
-```
-
-Would be the same as:
-
-```ts
-const { TvSVGIcon } = ReactMDIconSVG;
-```
+react-md has been split into two additional bundles if you want to use the
+existing material icon components. Everything is the same as the base UMD bundle
+except these bundles use a different file name and export the icon components.
 
 To use the UMD bundle, choose either the font or svg icon bundle and a new
-`<script>` tag to your `index.html` **after** the base react-md bundle:
+`<script>` tag to your `index.html` **instead** the base react-md bundle:
 
 ```diff
    <body>
      <noscript>You need to enable JavaScript to run this app.</noscript>
      <div id="root"></div>
-     <script src="https://unpkg.com/react-md@{{RMD_VERSION}}/dist/umd/react-md.production.min.js"></script>
+-    <script src="https://unpkg.com/react-md@{{RMD_VERSION}}/dist/umd/react-md.production.min.js"></script>
 +    <!-- only choose one of the following for your app -->
-+    <script src="https://unpkg.com/react-md@{{RMD_VERSION}}/dist/umd/react-md.font-icon.production.min.js"></script>
-+    <script src="https://unpkg.com/react-md@{{RMD_VERSION}}/dist/umd/react-md.svg-icon.production.min.js"></script>
++    <script src="https://unpkg.com/react-md@{{RMD_VERSION}}/dist/umd/react-md-with-font-icons.production.min.js"></script>
++    <script src="https://unpkg.com/react-md@{{RMD_VERSION}}/dist/umd/react-md-with-svg-icons.production.min.js"></script>
      <!--
        This HTML file is a template.
        If you open it directly in the browser, you will see an empty page.
@@ -105,6 +84,9 @@ To use the UMD bundle, choose either the font or svg icon bundle and a new
      -->
    </body>
 ```
+
+Check out the #material-icons package for more information about the separate
+icon components.
 
 ## Using the CDN hosted pre-compiled themes
 

--- a/packages/documentation/src/guides/advanced-installation.md
+++ b/packages/documentation/src/guides/advanced-installation.md
@@ -54,6 +54,58 @@ To use the UMD bundle, you'll want to add a new `<script>` tag to your
 This _can_ be used with a custom webpack configuration as well, but requires a
 bit more work. Check out the documentation on [configuring externals].
 
+#### Using the CDN hosted Material Icon Components
+
+Since you'll normally only ever want to include either SVG icons or Font icons,
+the icon components have been separated into two separate bundles and can be
+referenced as `ReactMDIconFont` or `ReactMDIconSVG`.
+
+```ts
+import { TvFontIcon } from "react-md";
+```
+
+Would be the same as:
+
+```ts
+const { TvFontIcon } = ReactMDIconSVG;
+```
+
+Or with svg icons:
+
+```ts
+import { TvSVGIcon } from "react-md";
+```
+
+Would be the same as:
+
+```ts
+const { TvSVGIcon } = ReactMDIconSVG;
+```
+
+To use the UMD bundle, choose either the font or svg icon bundle and a new
+`<script>` tag to your `index.html` **after** the base react-md bundle:
+
+```diff
+   <body>
+     <noscript>You need to enable JavaScript to run this app.</noscript>
+     <div id="root"></div>
+     <script src="https://unpkg.com/react-md@{{RMD_VERSION}}/dist/umd/react-md.production.min.js"></script>
++    <!-- only choose one of the following for your app -->
++    <script src="https://unpkg.com/react-md@{{RMD_VERSION}}/dist/umd/react-md.font-icon.production.min.js"></script>
++    <script src="https://unpkg.com/react-md@{{RMD_VERSION}}/dist/umd/react-md.svg-icon.production.min.js"></script>
+     <!--
+       This HTML file is a template.
+       If you open it directly in the browser, you will see an empty page.
+
+       You can add webfonts, meta tags, or analytics to this file.
+       The build step will place the bundled scripts into the <body> tag.
+
+       To begin the development, run `npm start` or `yarn start`.
+       To create a production bundle, use `npm run build` or `yarn build`.
+     -->
+   </body>
+```
+
 ## Using the CDN hosted pre-compiled themes
 
 The base `react-md` package also pre-compiles a few different themes for you

--- a/packages/react-md/README.md
+++ b/packages/react-md/README.md
@@ -1,4 +1,4 @@
-# react-md [![codecov](https://codecov.io/gh/mlaursen/react-md/branch/master/graph/badge.svg)](https://codecov.io/gh/mlaursen/react-md) [![Build Status](https://travis-ci.org/mlaursen/react-md.svg?branch=next)](https://travis-ci.org/mlaursen/react-md) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-green.svg)](https://github.com/mlaursen/react-md/pulls) [![Join the chat at Slack](https://react-md.herokuapp.com/badge.svg)](https://react-md.herokuapp.com) [![Donate](https://img.shields.io/badge/donate-paypal-blue.svg?style=flat-square)](https://paypal.me/mlaursen03)
+# react-md [![codecov](https://codecov.io/gh/mlaursen/react-md/branch/master/graph/badge.svg)](https://codecov.io/gh/mlaursen/react-md) [![Build Status](https://travis-ci.org/mlaursen/react-md.svg?branch=master)](https://travis-ci.org/mlaursen/react-md) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-green.svg)](https://github.com/mlaursen/react-md/pulls) [![Join the chat at Slack](https://react-md.herokuapp.com/badge.svg)](https://react-md.herokuapp.com) [![Donate](https://img.shields.io/badge/donate-paypal-blue.svg?style=flat-square)](https://paypal.me/mlaursen03)
 
 Create an accessible React application with the
 [material design specifications](https://material.io/design/) and Scss.
@@ -234,12 +234,15 @@ estimated size for this library, check out the results below:
 ```sh
 $ yarn dev-utils libsize
 
-The gzipped UMD bundle size is:
- - dist/umd/react-md.production.min.js 55 B
+The gzipped UMD bundle sizes are:
+ - dist/umd/react-md.production.min.js 86.49 KB
+ - dist/umd/react-md-with-font-icons.production.min.js 186.23 KB
+ - dist/umd/react-md-with-svg-icons.production.min.js 196.03 KB
+
 
 The min and max gzipped CSS bundle sizes are:
- - dist/css/react-md.red-lime-100-light.min.css 61 B
- - dist/css/react-md.deep_orange-blue_grey-100-light.min.css 76 B
+ - dist/css/react-md.grey-deep_orange-200-light.min.css 15.65 KB
+ - dist/css/react-md.indigo-blue-400-dark.min.css 15.71 KB
 ```
 
 ## Contributing
@@ -248,4 +251,5 @@ Please read the [contributing guidelines](./.github/CONTRIBUTING.md) if you
 would like to contribute.
 
 [typescript]: https://www.typescriptlang.org/
-[create-react-app]: https://facebook.github.io/create-react-app/docs/getting-started
+[create-react-app]:
+  https://facebook.github.io/create-react-app/docs/getting-started

--- a/packages/react-md/rollup.config.js
+++ b/packages/react-md/rollup.config.js
@@ -7,26 +7,17 @@ function createConfig(type) {
   const globals = {
     react: 'React',
     'react-dom': 'ReactDOM',
-    'react-md': 'ReactMD',
   };
 
-  const external = ['react', 'react-dom', 'react-md'];
-
-  let umdSuffix;
   let fileNameSuffix;
   switch (type) {
     case 'svg':
-      umdSuffix = 'IconSVG';
-      fileNameSuffix = '.svg-icon';
+      fileNameSuffix = '-with-svg-icons';
       break;
     case 'font':
-      umdSuffix = 'IconFont';
-      fileNameSuffix = '.font-icon';
+      fileNameSuffix = '-with-font-icons';
       break;
     default:
-      external.pop();
-      delete globals['react-md'];
-      umdSuffix = '';
       fileNameSuffix = '';
   }
 
@@ -35,14 +26,14 @@ function createConfig(type) {
     output: [
       {
         file: `dist/umd/react-md${fileNameSuffix}.development.js`,
-        name: `ReactMD${umdSuffix}`,
+        name: 'ReactMD',
         format: 'umd',
         globals,
         sourcemap: true,
       },
       {
         file: `dist/umd/react-md${fileNameSuffix}.production.min.js`,
-        name: `ReactMD${umdSuffix}`,
+        name: 'ReactMD',
         format: 'umd',
         globals,
         plugins: [terser()],
@@ -55,7 +46,7 @@ function createConfig(type) {
 
       warn(warning);
     },
-    external,
+    external: ['react', 'react-dom'],
     plugins: [
       resolve(),
       commonjs(),

--- a/packages/react-md/rollup.config.js
+++ b/packages/react-md/rollup.config.js
@@ -3,43 +3,67 @@ import commonjs from '@rollup/plugin-commonjs';
 import replace from '@rollup/plugin-replace';
 import { terser } from 'rollup-plugin-terser';
 
-module.exports = {
-  input: 'src/index.ts',
-  output: [
-    {
-      file: 'dist/umd/react-md.development.js',
-      name: 'ReactMD',
-      format: 'umd',
-      globals: {
-        react: 'React',
-        'react-dom': 'ReactDOM',
-      },
-      sourcemap: true,
-    },
-    {
-      file: 'dist/umd/react-md.production.min.js',
-      name: 'ReactMD',
-      format: 'umd',
-      globals: {
-        react: 'React',
-        'react-dom': 'ReactDOM',
-      },
-      plugins: [terser()],
-    },
-  ],
-  onwarn: (warning, warn) => {
-    if (warning.code === 'THIS_IS_UNDEFINED') {
-      return;
-    }
+function createConfig(type) {
+  const globals = {
+    react: 'React',
+    'react-dom': 'ReactDOM',
+    'react-md': 'ReactMD',
+  };
 
-    warn(warning);
-  },
-  external: ['react', 'react-dom'],
-  plugins: [
-    resolve(),
-    commonjs(),
-    replace({
-      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
-    }),
-  ],
-};
+  const external = ['react', 'react-dom', 'react-md'];
+
+  let umdSuffix;
+  let fileNameSuffix;
+  switch (type) {
+    case 'svg':
+      umdSuffix = 'IconSVG';
+      fileNameSuffix = '.svg-icon';
+      break;
+    case 'font':
+      umdSuffix = 'IconFont';
+      fileNameSuffix = '.font-icon';
+      break;
+    default:
+      external.pop();
+      delete globals['react-md'];
+      umdSuffix = '';
+      fileNameSuffix = '';
+  }
+
+  return {
+    input: `src/${type}.ts`,
+    output: [
+      {
+        file: `dist/umd/react-md${fileNameSuffix}.development.js`,
+        name: `ReactMD${umdSuffix}`,
+        format: 'umd',
+        globals,
+        sourcemap: true,
+      },
+      {
+        file: `dist/umd/react-md${fileNameSuffix}.production.min.js`,
+        name: `ReactMD${umdSuffix}`,
+        format: 'umd',
+        globals,
+        plugins: [terser()],
+      },
+    ],
+    onwarn: (warning, warn) => {
+      if (warning.code === 'THIS_IS_UNDEFINED') {
+        return;
+      }
+
+      warn(warning);
+    },
+    external,
+    plugins: [
+      resolve(),
+      commonjs(),
+      replace({
+        'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+      }),
+    ],
+  };
+}
+
+module.exports = ['rollup', 'svg', 'font'].map(createConfig);


### PR DESCRIPTION
I goofed really badly with the `gzip-size` package and got super inaccurate UMD bundle sizes. After fixing them, I realized that including all the material icons in a single bundle was not great since you'll only ever want to use SVG icons OR Font icons in a "real" app. This separates the bundles and reflects the true size of react-md:

```sh
The gzipped UMD bundle sizes are:
 - dist/umd/react-md.production.min.js 86.49 KB                   # base library
 - dist/umd/react-md-with-font-icons.production.min.js 186.23 KB  # base library + *FontIcon components
 - dist/umd/react-md-with-svg-icons.production.min.js 196.03 KB   # base library + *SVGIcon components
     
The min and max gzipped CSS bundle sizes are:    
 - dist/css/react-md.grey-deep_orange-200-light.min.css 15.65 KB    
 - dist/css/react-md.indigo-blue-400-dark.min.css 15.71 KB
```

Instead of:

```sh
The gzipped UMD bundle size is:
 - dist/umd/react-md.production.min.js 55 B

The min and max gzipped CSS bundle sizes are:
 - dist/css/react-md.red-lime-100-light.min.css 61 B
 - dist/css/react-md.deep_orange-blue_grey-100-light.min.css 76 B
```

Not sure how I could have missed it that badly... But "good" news is that v2 is 12% smaller than v1 excluding the material icon wrapper components.