### PR TITLE
adding focus handler for tooltip container events

### DIFF
--- a/src/js/Tooltips/TooltipContainer.js
+++ b/src/js/Tooltips/TooltipContainer.js
@@ -79,6 +79,7 @@ export default class TooltipContainer extends PureComponent {
       target.removeEventListener('mouseover', this._showTooltip);
       target.removeEventListener('mouseleave', this._hideTooltip);
       target.removeEventListener('keyup', this._handleKeyUp);
+      target.removeEventListener('focus', this._showTooltip);
       target.removeEventListener('focusout', this._hideTooltip);
       target.removeEventListener('blur', this._hideTooltip);
     }
@@ -102,6 +103,7 @@ export default class TooltipContainer extends PureComponent {
       target.addEventListener('mouseover', this._showTooltip);
       target.addEventListener('mouseleave', this._hideTooltip);
       target.addEventListener('keyup', this._handleKeyUp);
+      target.addEventListener('focus', this._showTooltip);
       target.addEventListener('focusout', this._hideTooltip);
       target.addEventListener('blur', this._hideTooltip);
     }


### PR DESCRIPTION
### Issue
Setting focus over **Button** elements with tooltipLabels, using **react ref** and [focus](https://developer.mozilla.org/en-US/docs/Web/API/HTMLOrForeignElement/focus) does`t make Tooltip to show up.
At the same time setting focus over **Button** using _Tab_ of _Shift + Tab_ does make Tooltip to show.
Issue could be reproduced in this [Sandbox](https://codesandbox.io/s/react-mdtooltip-focus-20cio?file=/src/App.js).

### Possible solution
Adding an event listener for the focus event in **TootipContainer** seems to solve this problem.