### PR TITLE
Fixed React warnings introduced in #947 & #949

### DIFF
--- a/src/js/Helpers/FocusContainer.js
+++ b/src/js/Helpers/FocusContainer.js
@@ -231,6 +231,8 @@ export default class FocusContainer extends PureComponent {
     const {
       component: Component,
       /* eslint-disable no-unused-vars */
+      componentRef,
+      containerRef,
       initialFocus,
       focusOnMount,
       containFocus,

--- a/src/js/SelectionControls/SelectionControl.js
+++ b/src/js/SelectionControls/SelectionControl.js
@@ -397,6 +397,7 @@ export default class SelectionControl extends PureComponent {
       checked: propChildren,
       onChange,
       tooltip,
+      changeOnEnter,
       checkedCheckboxIcon,
       uncheckedCheckboxIcon,
       checkedRadioIcon,


### PR DESCRIPTION
I've fixed React warnings (for example, `Warning: React does not recognize the containerRef prop on a DOM element.`) that I introduced in #947 and #949.
Sorry for the omission and inconvenience.