### PR TITLE
Fix ListItem Disabled Behavior

### DIFF
--- a/packages/list/src/ListItem.tsx
+++ b/packages/list/src/ListItem.tsx
@@ -48,13 +48,12 @@ export const ListItem = forwardRef<HTMLLIElement, ListItemProps>(
       rippleClassName,
       rippleContainerClassName,
       role = "button",
-      tabIndex = 0,
+      disabled = false,
+      tabIndex = disabled ? -1 : 0,
       ...props
     },
     ref
   ) {
-    const { disabled } = props;
-
     const { ripples, className, handlers } = useInteractionStates({
       className: propClassName,
       handlers: props,
@@ -84,6 +83,7 @@ export const ListItem = forwardRef<HTMLLIElement, ListItemProps>(
         {...handlers}
         ref={ref}
         tabIndex={tabIndex}
+        disabled={disabled}
         role={role}
         className={className}
         clickable

--- a/packages/list/src/SimpleListItem.tsx
+++ b/packages/list/src/SimpleListItem.tsx
@@ -39,6 +39,7 @@ export const SimpleListItem = forwardRef<HTMLLIElement, SimpleListItemProps>(
       clickable = false,
       onClick,
       disabled = false,
+      disabledOpacity = false,
       ...props
     },
     ref
@@ -66,6 +67,8 @@ export const SimpleListItem = forwardRef<HTMLLIElement, SimpleListItemProps>(
             "three-lines": threeLines,
             clickable,
             disabled: isDisabled,
+            "disabled-color": isDisabled && !disabledOpacity,
+            "disabled-opacity": isDisabled && disabledOpacity,
           }),
           className
         )}

--- a/packages/list/src/__tests__/ListItem.tsx
+++ b/packages/list/src/__tests__/ListItem.tsx
@@ -49,4 +49,17 @@ describe("ListItem", () => {
     rerender(<ListItem {...props} tabIndex={0} disabled />);
     expect(item.tabIndex).toBe(0);
   });
+
+  it("should apply the correct disabled classes based on the disabledOpacity prop", () => {
+    const props = { disabled: true, children: "Content" };
+    const { rerender, getByRole } = render(<ListItem {...props} />);
+
+    const item = getByRole("button");
+    expect(item.className).toContain("rmd-list-item--disabled-color");
+    expect(item.className).not.toContain("rmd-list-item--disabled-opacity");
+
+    rerender(<ListItem {...props} disabledOpacity />);
+    expect(item.className).not.toContain("rmd-list-item--disabled-color");
+    expect(item.className).toContain("rmd-list-item--disabled-opacity");
+  });
 });

--- a/packages/list/src/__tests__/ListItem.tsx
+++ b/packages/list/src/__tests__/ListItem.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/tabindex-no-positive */
 import React from "react";
 import { render, fireEvent } from "@testing-library/react";
 
@@ -28,5 +29,24 @@ describe("ListItem", () => {
     expect(item.className).toContain("rmd-list-item--disabled");
     fireEvent.click(item);
     expect(onClick).not.toBeCalled();
+  });
+
+  it("should default the tabIndex to 0 when not disabled and to -1 when disabled", () => {
+    const props = { children: "Content" };
+    const { rerender, getByRole } = render(<ListItem {...props} />);
+    const item = getByRole("button");
+    expect(item.tabIndex).toBe(0);
+
+    rerender(<ListItem {...props} disabled />);
+    expect(item.tabIndex).toBe(-1);
+
+    rerender(<ListItem {...props} tabIndex={1} />);
+    expect(item.tabIndex).toBe(1);
+
+    rerender(<ListItem {...props} tabIndex={1} disabled />);
+    expect(item.tabIndex).toBe(1);
+
+    rerender(<ListItem {...props} tabIndex={0} disabled />);
+    expect(item.tabIndex).toBe(0);
   });
 });

--- a/packages/list/src/__tests__/SimpleListItem.tsx
+++ b/packages/list/src/__tests__/SimpleListItem.tsx
@@ -39,4 +39,17 @@ describe("SimpleListItem", () => {
     fireEvent.click(item);
     expect(onClick).toBeCalled();
   });
+
+  it("should apply the correct disabled classes based on the disabledOpacity prop", () => {
+    const props = { role: "button", disabled: true, children: "Content" };
+    const { rerender, getByRole } = render(<SimpleListItem {...props} />);
+
+    const item = getByRole("button");
+    expect(item.className).toContain("rmd-list-item--disabled-color");
+    expect(item.className).not.toContain("rmd-list-item--disabled-opacity");
+
+    rerender(<SimpleListItem {...props} disabledOpacity />);
+    expect(item.className).not.toContain("rmd-list-item--disabled-color");
+    expect(item.className).toContain("rmd-list-item--disabled-opacity");
+  });
 });

--- a/packages/list/src/_mixins.scss
+++ b/packages/list/src/_mixins.scss
@@ -184,9 +184,19 @@
   }
 
   &--disabled {
-    @include rmd-theme(color, text-disabled-on-background);
-
     pointer-events: none;
+  }
+
+  &--disabled-color {
+    @include rmd-theme(color, text-disabled-on-background);
+    @include rmd-theme-update-var(
+      text-secondary-on-background,
+      rmd-theme-var(text-disabled-on-background)
+    );
+  }
+
+  &--disabled-opacity {
+    opacity: $rmd-list-item-disabled-opacity;
   }
 
   &--link {

--- a/packages/list/src/_variables.scss
+++ b/packages/list/src/_variables.scss
@@ -158,6 +158,13 @@ $rmd-list-item-media-large-size: 6.25rem !default;
 /// @type Number
 $rmd-list-item-media-spacing: 1rem !default;
 
+/// The opacity to apply to a list item when it is `disabled` and the
+/// `disabledOpacity` boolean is enabled that will also darken any addons
+/// rendered in the list item.
+///
+/// @type Number
+$rmd-list-item-disabled-opacity: 0.5 !default;
+
 /// A Map of all the "themeable" parts of the list package. Every key in this
 /// map will be used to create a css variable to dynamically update the values
 /// of the icon as needed.

--- a/packages/list/src/getListItemHeight.ts
+++ b/packages/list/src/getListItemHeight.ts
@@ -19,6 +19,17 @@ export interface SimpleListItemProps
   disabled?: boolean;
 
   /**
+   * Boolean if the list item should apply an opacity value while disabled
+   * instead of overriding the primary and secondary text colors. Enabling this
+   * will allow for the list item addons to also be dimmed.
+   *
+   * This is configured by the `$rmd-list-item-disabled-opacity` variable.
+   *
+   * Note: This does nothing if the `disabled` prop is not enabled.
+   */
+  disabledOpacity?: boolean;
+
+  /**
    * Boolean if the list item should be updated to use the clickable styles to
    * the item. This is really just a pass-down value for the main `ListItem`
    * component and shouldn't really be used unless you are implementing your own


### PR DESCRIPTION
This PR includes:

- Preventing the `ListItem` from being focusable by default when disabled. This better mimics the button behavior that it inherits, but can still be set to 0 or another tabIndex if needed.
- Correctly set the disabled color to `ListItem` secondary text
- Adding a new prop to the `ListItem` that allows the `disabled` state to be applied with opacity instead of colors. This allows for the addons to also gain a disabled state
- introduce a new `$rmd-list-item-disabled-opacity: 0.5! default;` value for the `disabledOpacity` prop

Closes #997 

### Visual Examples

#### Light Theme

##### Default ListItem

<img alt="ListItem Example" src="https://user-images.githubusercontent.com/3920850/99136250-22fff080-25e1-11eb-9bc0-f07d1f5e3311.png" width="411">

##### Disabled ListItem

<img alt="ListItem Example" src="https://user-images.githubusercontent.com/3920850/99136392-c6e99c00-25e1-11eb-87c3-1c157e8282ef.png" width="411">

###### Disabled Opacity ListItem

<img alt="ListItem Example" src="https://user-images.githubusercontent.com/3920850/99136391-c6510580-25e1-11eb-912a-5ff9db7dbb9c.png" width="411">

##### Default ListItem with Addons

<img alt="ListItem Example" src="https://user-images.githubusercontent.com/3920850/99136312-6a867c80-25e1-11eb-84e8-f208495884a2.png" width="411">

##### Disabled ListItem with Addons

<img alt="ListItem Example" src="https://user-images.githubusercontent.com/3920850/99136487-4d05e280-25e2-11eb-8b25-f4aab3d956e4.png" width="411">

##### Disabled Opacity ListItem with Addons

<img alt="ListItem Example" src="https://user-images.githubusercontent.com/3920850/99136489-4d9e7900-25e2-11eb-83ed-0293d759a4db.png" width="411">

#### Dark Theme

##### Default ListItem

<img alt="ListItem Example" src="https://user-images.githubusercontent.com/3920850/99136572-e92fe980-25e2-11eb-8bbe-ba547245bc89.png" width="411">

##### Disabled ListItem

<img alt="ListItem Example" src="https://user-images.githubusercontent.com/3920850/99136571-e8975300-25e2-11eb-83d1-988f0555b095.png" width="411">

###### Disabled Opacity ListItem

<img alt="ListItem Example" src="https://user-images.githubusercontent.com/3920850/99136570-e8975300-25e2-11eb-9c31-6ada84c89908.png" width="411">

##### Default ListItem with Addons

<img alt="ListItem Example" src="https://user-images.githubusercontent.com/3920850/99136610-34e29300-25e3-11eb-83cb-578618b62e69.png" width="411">

##### Disabled ListItem with Addons

<img alt="ListItem Example" src="https://user-images.githubusercontent.com/3920850/99136608-33b16600-25e3-11eb-9046-556a9dd2a253.png" width="411">

##### Disabled Opacity ListItem with Addons

<img alt="ListItem Example" src="https://user-images.githubusercontent.com/3920850/99136609-34e29300-25e3-11eb-9b49-36bd18e2aba4.png" width="411">

