### PR TITLE
Bugfix/dark elevation

### DIFF
--- a/packages/alert/src/_mixins.scss
+++ b/packages/alert/src/_mixins.scss
@@ -72,7 +72,6 @@
 /// internally.
 @mixin rmd-toast {
   @include rmd-elevation($rmd-toast-elevation);
-  @include rmd-theme-dark-elevation($rmd-toast-elevation);
   @include rmd-typography(subtitle-2);
   @include rmd-alert-theme(background-color);
   @include rmd-alert-theme(color);

--- a/packages/alert/src/_variables.scss
+++ b/packages/alert/src/_variables.scss
@@ -18,6 +18,11 @@ $rmd-snackbar-margin: 1rem !default;
 /// @type Number
 $rmd-snackbar-z-index: $rmd-utils-temporary-element-z-index + 10 !default;
 
+/// The elevation to add to a toast. This will be used to create the correct
+/// box-shadow.
+/// @type Number
+$rmd-toast-elevation: 6 !default;
+
 /// The border radius to apply to a toast.
 /// @type Number
 $rmd-toast-border-radius: 0.25rem !default;
@@ -32,9 +37,25 @@ $rmd-toast-light-background-color: #323232 !default;
 /// @type Color
 $rmd-toast-light-color: $rmd-white-base !default;
 
+/// The background color for a toast in dark themes when the
+/// `$rmd-theme-dark-elevation` feature flag is also enabled.
+///
+/// @see $rmd-theme-dark-elevation
+/// @require $rmd-theme-dark-elevation-colors
+/// @type Color
+/// @since 2.7.0
+$rmd-toast-dark-elevation-background-color: map-get(
+  $rmd-theme-dark-elevation-colors,
+  $rmd-toast-elevation
+) !default;
+
 /// The background color for a toast in dark themes.
 /// @type Color
-$rmd-toast-dark-background-color: $rmd-toast-light-background-color !default;
+$rmd-toast-dark-background-color: if(
+  $rmd-theme-dark-elevation and $rmd-toast-dark-elevation-background-color,
+  $rmd-toast-dark-elevation-background-color,
+  $rmd-toast-light-background-color
+) !default;
 
 /// The text color for a toast in dark themes
 ///
@@ -94,11 +115,6 @@ $rmd-toast-action-margin: 0.5rem !default;
 /// stacked within the toast.
 /// @type Number
 $rmd-toast-stacked-action-margin-top: 0.25rem !default;
-
-/// The elevation to add to a toast. This will be used to create the correct
-/// box-shadow.
-/// @type Number
-$rmd-toast-elevation: 6 !default;
 
 /// The transition duration for the enter animation for a toast. If this value
 /// gets updated, you'll also need to update the `timoout` prop on the `Toast`

--- a/packages/card/src/_mixins.scss
+++ b/packages/card/src/_mixins.scss
@@ -73,25 +73,17 @@
       );
     }
   }
-  @include rmd-theme(background-color, surface);
-  @include rmd-theme(color, text-primary-on-background);
+  @include rmd-card-theme(background-color);
+  @include rmd-card-theme(color);
 
   border-radius: $rmd-card-border-radius;
   display: inline-block;
 
   &--shadowed {
     @include rmd-elevation($rmd-card-elevation);
-    @include rmd-theme-dark-elevation($rmd-card-elevation);
   }
 
   &--bordered {
-    @include rmd-theme-dark-elevation-styles {
-      @include rmd-theme-update-var(
-        surface,
-        $rmd-card-dark-elevation-bordered-background-color
-      );
-    }
-
     border: $rmd-card-border-width solid $rmd-card-border-color;
   }
 

--- a/packages/card/src/_variables.scss
+++ b/packages/card/src/_variables.scss
@@ -6,11 +6,52 @@
 @import '~@react-md/divider/dist/variables';
 @import '~@react-md/theme/dist/functions';
 
+/// The elevation to use for cards that are not raisable.
+/// @type Number
+$rmd-card-elevation: 2 !default;
+
+/// The background color for a card in light themes.
+///
+/// @type Color
+/// @since 2.7.0
+$rmd-card-light-background-color: rmd-theme-var(surface) !default;
+
+/// The background color for a card in dark themes when the
+/// `$rmd-theme-dark-elevation` feature flag is also enabled.
+///
+/// @see $rmd-theme-dark-elevation
+/// @require $rmd-theme-dark-elevation-colors
+/// @type Color
+/// @since 2.7.0
+$rmd-card-dark-elevation-background-color: map-get(
+  $rmd-theme-dark-elevation-colors,
+  $rmd-card-elevation
+);
+
+/// @type Color
+/// @since 2.5.4
+/// @deprecated Use `$rmd-card-dark-elevation-color` instead starting with `v2.7.0`
+$rmd-card-dark-elevation-bordered-background-color: $rmd-card-dark-elevation-background-color;
+
+/// The background color for a card in dark themes.
+///
+/// @type Color
+/// @since 2.7.0
+$rmd-card-dark-background-color: if(
+  $rmd-theme-dark-elevation and $rmd-card-dark-elevation-background-color,
+  $rmd-card-dark-elevation-background-color,
+  rmd-theme-var(surface)
+) !default;
+
 /// The base background color to apply to cards.
 ///
 /// @require rmd-theme-var
 /// @type Color
-$rmd-card-background-color: rmd-theme-var(surface) !default;
+$rmd-card-background-color: if(
+  $rmd-theme-light,
+  $rmd-card-light-background-color,
+  $rmd-card-dark-background-color
+) !default;
 
 /// The base primary text color to apply to cards.
 ///
@@ -31,10 +72,6 @@ $rmd-card-secondary-color: if(
   rmd-theme-var(text-primary-on-light),
   rmd-theme-var(text-primary-on-dark)
 ) !default;
-
-/// The elevation to use for cards that are not raisable.
-/// @type Number
-$rmd-card-elevation: 2 !default;
 
 /// The starting elevation for a raisable card.
 /// @type Number
@@ -89,19 +126,6 @@ $rmd-card-border-color: rmd-divider-theme-var(background-color) !default;
 /// @require $rmd-divider-size
 /// @type Number
 $rmd-card-border-width: $rmd-divider-size !default;
-
-/// The background color to use for bordered cards when the
-/// `$rmd-theme-dark-elevation` variable is set to `true`. This basically
-/// overrides the `surface` color to be this value.
-///
-/// @see $rmd-theme-dark-elevation
-/// @require $rmd-theme-dark-elevation-colors
-/// @type Color
-/// @since 2.5.4
-$rmd-card-dark-elevation-bordered-background-color: map-get(
-  $rmd-theme-dark-elevation-colors,
-  $rmd-card-elevation
-);
 
 /// A Map of all the "themeable" parts of the card package. Every key in this
 /// map will be used to create a css variable to dynamically update the values

--- a/packages/dialog/src/_mixins.scss
+++ b/packages/dialog/src/_mixins.scss
@@ -50,9 +50,11 @@
 /// @access private
 @mixin rmd-dialog {
   @include rmd-elevation($rmd-dialog-elevation);
-  @include rmd-theme-dark-elevation($rmd-dialog-elevation);
-  @include rmd-theme-update-var(background, rmd-theme-var(surface));
-  @include rmd-theme(background-color, background);
+  @include rmd-dialog-theme(background-color);
+  @include rmd-theme-update-var(
+    background,
+    rmd-dialog-theme-var(background-color)
+  );
   @include rmd-theme(color, text-primary-on-background);
   @include rmd-utils-hide-focus-outline;
   @if mixin-exists(rmd-app-bar-theme-update-var) {

--- a/packages/dialog/src/_variables.scss
+++ b/packages/dialog/src/_variables.scss
@@ -3,6 +3,8 @@
 ////
 
 @import '~@react-md/overlay/dist/variables';
+@import '~@react-md/theme/dist/variables';
+@import '~@react-md/theme/dist/functions';
 @import '~@react-md/utils/dist/variables';
 
 /// The elevation (box-shadow) to use for the dialog when it is not full page.
@@ -11,6 +13,44 @@
 ///
 /// @type Number
 $rmd-dialog-elevation: 16 !default;
+
+/// The background color for a dialog in light themes.
+///
+/// @type Color
+/// @since 2.7.0
+$rmd-dialog-light-background-color: rmd-theme-var(surface) !default;
+
+/// The background color for a dialog in dark themes when the
+/// `$rmd-theme-dark-elevation` feature flag is also enabled.
+///
+/// @see $rmd-theme-dark-elevation
+/// @require $rmd-theme-dark-elevation-colors
+/// @type Color
+/// @since 2.7.0
+$rmd-dialog-dark-elevation-background-color: map-get(
+  $rmd-theme-dark-elevation-colors,
+  $rmd-dialog-elevation
+) !default;
+
+/// The background color for a dialog in dark themes.
+///
+/// @type Color
+/// @since 2.7.0
+$rmd-dialog-dark-background-color: if(
+  $rmd-theme-dark-elevation and $rmd-dialog-dark-elevation-background-color,
+  $rmd-dialog-dark-elevation-background-color,
+  rmd-theme-var(surface)
+) !default;
+
+/// The base background color to apply to dialogs.
+///
+/// @type Color
+/// @since 2.7.0
+$rmd-dialog-background-color: if(
+  $rmd-theme-light,
+  $rmd-dialog-light-background-color,
+  $rmd-dialog-dark-background-color
+) !default;
 
 /// The z-index for dialogs. This value is a bit larger than overlays just in
 /// case other components are using the overlay as well. The dialog's overlay
@@ -77,6 +117,7 @@ $rmd-dialog-min-width: 17.5rem !default;
 /// of the icon as needed.
 /// @type Map
 $rmd-dialog-theme-values: (
+  background-color: $rmd-dialog-background-color,
   horizontal-margin: $rmd-dialog-horizontal-margin,
   vertical-margin: $rmd-dialog-vertical-margin,
   min-width: $rmd-dialog-min-width,

--- a/packages/documentation/src/components/PackageSassDoc/Parameters.tsx
+++ b/packages/documentation/src/components/PackageSassDoc/Parameters.tsx
@@ -26,7 +26,7 @@ const Parameters: FC<ParametersProps> = ({ parameters }) => {
 
   return (
     <TableContainer>
-      <Table>
+      <Table disableHover>
         <caption className={styles.caption}>Parameters</caption>
         <TableHeader>
           <TableRow>

--- a/packages/documentation/src/components/PackageSassDoc/ReferenceLinkSection.module.scss
+++ b/packages/documentation/src/components/PackageSassDoc/ReferenceLinkSection.module.scss
@@ -1,0 +1,16 @@
+@import '~@react-md/icon/dist/mixins';
+
+.container {
+  align-items: center;
+  display: flex;
+}
+
+// this should only happen when the previous `ReferenceLinkSection` is collapsed
+.container + .container {
+  margin-top: 1rem;
+}
+
+.chevron {
+  @include rmd-icon-theme-update-var(rotate-from, rotate(90deg));
+  @include rmd-icon-theme-update-var(rotate-to, rotate(270deg));
+}

--- a/packages/documentation/src/components/PackageSassDoc/ReferenceLinkSection.tsx
+++ b/packages/documentation/src/components/PackageSassDoc/ReferenceLinkSection.tsx
@@ -1,32 +1,49 @@
-import React, { FC } from "react";
+import React, { ReactElement, ReactNode, useState } from "react";
+import { Button } from "@react-md/button";
+import { IconRotator } from "@react-md/icon";
+import { ChevronLeftSVGIcon } from "@react-md/material-icons";
+import { Collapse } from "@react-md/transition";
 import { Text } from "@react-md/typography";
 
 import { ItemReferenceLink } from "utils/sassdoc";
 
 import ReferenceLinkList from "./ReferenceLinkList";
+import styles from "./ReferenceLinkSection.module.scss";
 
 export interface ReferenceLinkSectionProps {
   links: ItemReferenceLink[] | undefined;
+  children: ReactNode;
 }
 
-const ReferenceLinkSection: FC<ReferenceLinkSectionProps> = ({
+export default function ReferenceLinkSection({
   children,
   links,
-}) => {
+}: ReferenceLinkSectionProps): ReactElement | null {
+  const [collapsed, setCollapsed] = useState(true);
   if (!links || !links.length) {
     return null;
   }
 
   return (
     <>
-      <Text type="headline-6" margin="top">
+      <Text type="headline-6" margin="top" className={styles.container}>
         {children}
+        <Button
+          aria-label="Expand"
+          aria-pressed={!collapsed}
+          onClick={() => setCollapsed((p) => !p)}
+          buttonType="icon"
+        >
+          <IconRotator rotated={!collapsed}>
+            <ChevronLeftSVGIcon className={styles.chevron} />
+          </IconRotator>
+        </Button>
       </Text>
-      <ul>
-        <ReferenceLinkList links={links} />
-      </ul>
+      <Collapse collapsed={collapsed}>
+        <ul>
+          <ReferenceLinkList links={links} />
+        </ul>
+      </Collapse>
     </>
   );
-};
-
-export default ReferenceLinkSection;
+}

--- a/packages/form/src/_variables.scss
+++ b/packages/form/src/_variables.scss
@@ -76,6 +76,7 @@ $rmd-form-theme-values: (
   label-top-offset: 0px,
   label-active-padding: 0px,
   label-active-background-color: transparent,
+  listbox-background-color: $rmd-listbox-background-color,
   text-padding-left: 0px,
   text-padding-right: 0px,
   text-padding-top: 0px,

--- a/packages/form/src/select/_mixins.scss
+++ b/packages/form/src/select/_mixins.scss
@@ -120,8 +120,7 @@
 
   &--temporary {
     @include rmd-elevation($rmd-listbox-elevation);
-    @include rmd-theme-dark-elevation($rmd-listbox-elevation);
-    @include rmd-theme(background-color, surface);
+    @include rmd-form-theme(background-color, listbox-background-color);
     @include rmd-theme(color, on-surface);
 
     z-index: $rmd-listbox-z-index;

--- a/packages/form/src/select/_variables.scss
+++ b/packages/form/src/select/_variables.scss
@@ -3,6 +3,7 @@
 ////
 
 @import '~@react-md/theme/dist/color-palette';
+@import '~@react-md/theme/dist/functions';
 @import '~@react-md/utils/dist/variables';
 
 /// The additional amount of apdding to apply to the top of the select field
@@ -17,16 +18,54 @@ $rmd-select-native-multiple-padding: 0.75rem !default;
 /// @type Number
 $rmd-select-native-addon-top: 1rem !default;
 
+/// The elevation level for a temporary listbox. This should be a number between
+/// 0-24 as it generates a material design box shadow value.
+/// @type Number
+$rmd-listbox-elevation: 8 !default;
+
+/// The background color for a temporary listbox in light themes.
+///
+/// @type Color
+/// @since 2.7.0
+$rmd-listbox-light-background-color: rmd-theme-var(surface) !default;
+
+/// The background color for a temporary listbox in dark themes when the
+/// `$rmd-theme-dark-elevation` feature flag is also enabled.
+///
+/// @see $rmd-theme-dark-elevation
+/// @require $rmd-theme-dark-elevation-colors
+/// @type Color
+/// @since 2.7.0
+$rmd-listbox-dark-elevation-background-color: map-get(
+  $rmd-theme-dark-elevation-colors,
+  $rmd-listbox-elevation
+) !default;
+
+/// The background color for a temporary listbox in dark themes.
+///
+/// @type Color
+/// @since 2.7.0
+$rmd-listbox-dark-background-color: if(
+  $rmd-theme-dark-elevation and $rmd-listbox-dark-elevation-background-color,
+  $rmd-listbox-dark-elevation-background-color,
+  rmd-theme-var(surface)
+) !default;
+
+/// The base background color to apply to temporary listboxes.
+///
+/// @type Color
+/// @since 2.7.0
+$rmd-listbox-background-color: if(
+  $rmd-theme-light,
+  $rmd-listbox-light-background-color,
+  $rmd-listbox-dark-background-color
+) !default;
+
 /// The z-index to use for a temporary listbox.
 ///
 /// @require $rmd-utils-temporary-element-z-index
 /// @type Number
 $rmd-listbox-z-index: $rmd-utils-temporary-element-z-index !default;
-
-/// The elevation level for a temporary listbox. This should be a number between
-/// 0-24 as it generates a material design box shadow value.
-/// @type Number
-$rmd-listbox-elevation: 8 !default;
 
 /// The styles to apply when an option is focused with `aria-activedescendant`
 /// behavior. This should be a map of styles that should be applied.

--- a/packages/menu/src/_mixins.scss
+++ b/packages/menu/src/_mixins.scss
@@ -51,7 +51,6 @@
   @include rmd-utils-hide-focus-outline;
   @include rmd-utils-scroll;
   @include rmd-elevation($rmd-menu-elevation);
-  @include rmd-theme-dark-elevation($rmd-menu-elevation);
   @include rmd-menu-theme(background-color);
   @include rmd-menu-theme(color);
   @include rmd-menu-theme(min-width);

--- a/packages/menu/src/_variables.scss
+++ b/packages/menu/src/_variables.scss
@@ -6,11 +6,48 @@
 @import '~@react-md/list/dist/functions';
 @import '~@react-md/utils/dist/variables';
 
+/// The elevation for menus. This should be a number from 0 to 24 (inclusive) as
+/// it gets passed to the `rmd-elevation` mixin.
+/// @type Number
+$rmd-menu-elevation: 8 !default;
+
+/// The background color for a menu in light themes.
+///
+/// @type Color
+/// @since 2.7.0
+$rmd-menu-light-background-color: rmd-theme-var(surface) !default;
+
+/// The background color for a menu in dark themes when the
+/// `$rmd-theme-dark-elevation` feature flag is also enabled.
+///
+/// @see $rmd-theme-dark-elevation
+/// @see $rmd-menu-dark-background-color
+/// @require $rmd-theme-dark-elevation-colors
+/// @type Color
+/// @since 2.7.0
+$rmd-menu-dark-elevation-background-color: map-get(
+  $rmd-theme-dark-elevation-colors,
+  $rmd-menu-elevation
+) !default;
+
+/// The background color for a menu in dark themes.
+/// @type Color
+/// @since 2.7.0
+$rmd-menu-dark-background-color: if(
+  $rmd-theme-dark-elevation and $rmd-menu-dark-elevation-background-color,
+  $rmd-menu-dark-elevation-background-color,
+  rmd-theme-var(surface)
+) !default;
+
 /// The background color to use for menus
 ///
 /// @require rmd-theme-var
 /// @type Color
-$rmd-menu-background-color: rmd-theme-var(surface) !default;
+$rmd-menu-background-color: if(
+  $rmd-theme-light,
+  $rmd-menu-light-background-color,
+  $rmd-menu-dark-background-color
+) !default;
 
 /// The text color to use for menus
 ///
@@ -23,11 +60,6 @@ $rmd-menu-color: rmd-theme-var(on-surface) !default;
 /// @require $rmd-utils-temporary-element-z-index
 /// @type Number
 $rmd-menu-z-index: $rmd-utils-temporary-element-z-index !default;
-
-/// The elevation for menus. This should be a number from 0 to 24 (inclusive) as
-/// it gets passed to the `rmd-elevation` mixin.
-/// @type Number
-$rmd-menu-elevation: 8 !default;
 
 /// The min-width to apply to menus.
 /// @type Number

--- a/packages/sheet/src/_mixins.scss
+++ b/packages/sheet/src/_mixins.scss
@@ -100,8 +100,11 @@
 
 /// Creates the styles for a sheet component
 @mixin rmd-sheet {
+  @if $rmd-theme-dark-elevation {
+    @include rmd-sheet-theme(background-color);
+  }
+
   @include rmd-elevation($rmd-sheet-elevation);
-  @include rmd-theme-dark-elevation($rmd-sheet-elevation);
   @include rmd-utils-scroll;
   @include rmd-sheet-positions;
   @include rmd-sheet-theme(max-height);
@@ -112,8 +115,13 @@
   z-index: $rmd-sheet-z-index;
 
   &--raised {
+    @if $rmd-theme-dark-elevation {
+      @include rmd-sheet-theme-update-var(
+        background-color,
+        rmd-sheet-theme-var(raised-background-color)
+      );
+    }
     @include rmd-elevation($rmd-sheet-raised-elevation);
-    @include rmd-theme-dark-elevation($rmd-sheet-elevation);
 
     z-index: $rmd-sheet-raised-z-index;
   }
@@ -199,7 +207,17 @@
 /// Creates all the styles for the sheet package as well as the root css
 /// variable theme.
 @mixin react-md-sheet {
-  @include rmd-theme-create-root-theme($rmd-sheet-theme-values, sheet);
+  $exclude: if(
+    $rmd-theme-dark-elevation,
+    (),
+    (background-color, raised-background-color)
+  );
+
+  @include rmd-theme-create-root-theme(
+    $rmd-sheet-theme-values,
+    sheet,
+    $exclude
+  );
 
   .rmd-sheet {
     @include rmd-sheet;

--- a/packages/sheet/src/_variables.scss
+++ b/packages/sheet/src/_variables.scss
@@ -2,6 +2,7 @@
 /// @group sheet
 ////
 
+@import '~@react-md/dialog/dist/variables';
 @import '~@react-md/overlay/dist/variables';
 @import '~@react-md/transition/dist/variables';
 @import '~@react-md/theme/dist/functions';
@@ -39,6 +40,114 @@ $rmd-sheet-elevation: 2 !default;
 /// well.
 /// @type Number
 $rmd-sheet-raised-elevation: 16 !default;
+
+/// The background color for a sheet rendered "inline" with other content in the
+/// light theme.
+///
+/// Note: If `$rmd-theme-dark-elevation` is set to `false`, this variable is
+/// ignored and the color is determined by the normal dialog background color
+/// instead.
+///
+/// @type Color
+/// @since 2.7.0
+$rmd-sheet-light-background-color: rmd-dialog-theme-var(
+  background-color
+) !default;
+
+/// The background color for a sheet rendered "inline" with other content in the
+/// dark theme and the `$rmd-theme-dark-elevation` feature flag is also enabled.
+///
+/// @see $rmd-theme-dark-elevation
+/// @require $rmd-theme-dark-elevation-colors
+/// @type Color
+/// @since 2.7.0
+$rmd-sheet-dark-elevation-background-color: map-get(
+  $rmd-theme-dark-elevation-colors,
+  $rmd-sheet-elevation
+) !default;
+
+/// The background color for a sheet rendered "inline" with other content in the
+/// dark theme.
+///
+/// Note: If `$rmd-theme-dark-elevation` is set to `false`, this variable is
+/// ignored and the color is determined by the normal dialog background color
+/// instead.
+///
+/// @type Color
+/// @since 2.7.0
+$rmd-sheet-dark-background-color: if(
+  $rmd-theme-dark-elevation,
+  $rmd-sheet-dark-elevation-background-color,
+  rmd-dialog-theme-var(background-color)
+) !default;
+
+/// The background color for a sheet rendered "inline" with other content.
+///
+/// Note: If `$rmd-theme-dark-elevation` is set to `false`, this variable is
+/// ignored and the color is determined by the normal dialog background color
+/// instead.
+///
+/// @type Color
+/// @since 2.7.0
+$rmd-sheet-background-color: if(
+  $rmd-theme-light,
+  $rmd-sheet-light-background-color,
+  $rmd-theme-dark-background-color
+) !default;
+
+/// The background color for a sheet raised above other content in the light
+/// theme.
+///
+/// Note: If `$rmd-theme-dark-elevation` is set to `false`, this variable is
+/// ignored and the color is determined by the normal dialog background color
+/// instead.
+///
+/// @type Color
+/// @since 2.7.0
+$rmd-sheet-raised-light-background-color: rmd-dialog-theme-var(
+  background-color
+) !default;
+
+/// The background color for a sheet raised above other content in the dark
+/// theme and the `$rmd-theme-dark-elevation` feature flag is also enabled.
+///
+/// @see $rmd-theme-dark-elevation
+/// @require $rmd-theme-dark-elevation-colors
+/// @type Color
+/// @since 2.7.0
+$rmd-sheet-raised-dark-elevation-background-color: map-get(
+  $rmd-theme-dark-elevation-colors,
+  $rmd-sheet-raised-elevation
+) !default;
+
+/// The background color for a sheet raised above other content in the dark
+/// theme.
+///
+/// Note: If `$rmd-theme-dark-elevation` is set to `false`, this variable is
+/// ignored and the color is determined by the normal dialog background color
+/// instead.
+///
+/// @type Color
+/// @since 2.7.0
+$rmd-sheet-raised-dark-background-color: if(
+  $rmd-theme-dark-elevation,
+  $rmd-sheet-raised-dark-elevation-background-color,
+  rmd-dialog-theme-var(background-color)
+) !default;
+
+/// The background color for a sheet raised above other content.
+///
+/// Note: If `$rmd-theme-dark-elevation` is set to `false`, this variable is
+/// ignored and the color is determined by the normal dialog background color
+/// instead.
+///
+/// @type Color
+/// @since 2.7.0
+$rmd-sheet-raised-background-color: if(
+  $rmd-theme-light,
+  $rmd-sheet-raised-light-background-color,
+  $rmd-theme-raised-dark-background-color
+) !default;
 
 /// The duration for the enter transition.
 ///
@@ -108,6 +217,8 @@ $rmd-sheet-enabled-positions: $rmd-sheet-positions !default;
 /// of the icon as needed.
 /// @type Map
 $rmd-sheet-theme-values: (
+  background-color: $rmd-sheet-background-color,
+  raised-background-color: $rmd-sheet-raised-background-color,
   touch-width: $rmd-sheet-touch-width,
   static-width: $rmd-sheet-static-width,
   touchable-max-height: $rmd-sheet-touchable-max-height,

--- a/packages/theme/src/_mixins.scss
+++ b/packages/theme/src/_mixins.scss
@@ -137,6 +137,18 @@
     $rmd-theme-icon-on-light-color
   );
 
+  @if mixin-exists(rmd-alert-theme-update-var) {
+    @if $rmd-toast-light-background-color != $rmd-toast-dark-background-color {
+      @include rmd-alert-theme-update-var(
+        background-color,
+        $rmd-toast-light-background-color
+      );
+    }
+    @if $rmd-toast-light-color != $rmd-toast-dark-color {
+      @include rmd-alert-theme-update-var(color, $rmd-toast-light-color);
+    }
+  }
+
   @if mixin-exists(rmd-app-bar-theme-update-var) {
     @include rmd-app-bar-theme-update-var(
       default-background-color,
@@ -282,6 +294,21 @@
     text-icon-on-background,
     $rmd-theme-icon-on-dark-color
   );
+
+  @if mixin-exists(rmd-alert-theme-update-var) {
+    @if $rmd-toast-light-color != $rmd-toast-dark-color {
+      @include rmd-alert-theme-update-var(
+        background-color,
+        $rmd-toast-dark-color
+      );
+    }
+    @if $rmd-toast-light-background-color != $rmd-toast-dark-background-color {
+      @include rmd-alert-theme-update-var(
+        background-color,
+        $rmd-toast-dark-background-color
+      );
+    }
+  }
 
   @if mixin-exists(rmd-app-bar-theme-update-var) {
     @include rmd-app-bar-theme-update-var(

--- a/packages/theme/src/_mixins.scss
+++ b/packages/theme/src/_mixins.scss
@@ -201,6 +201,16 @@
     );
   }
 
+  @if mixin-exists(rmd-dialog-theme-update-var) {
+    @if $rmd-dialog-light-background-color != $rmd-dialog-dark-background-color
+    {
+      @include rmd-dialog-theme-update-var(
+        background-color,
+        $rmd-dialog-light-background-color
+      );
+    }
+  }
+
   @if mixin-exists(rmd-divider-theme-update-var) {
     @include rmd-divider-theme-update-var(
       background-color,
@@ -373,6 +383,16 @@
       outline-color,
       $rmd-chip-outline-dark-color
     );
+  }
+
+  @if mixin-exists(rmd-dialog-theme-update-var) {
+    @if $rmd-dialog-light-background-color != $rmd-dialog-dark-background-color
+    {
+      @include rmd-dialog-theme-update-var(
+        background-color,
+        $rmd-dialog-dark-background-color
+      );
+    }
   }
 
   @if mixin-exists(rmd-divider-theme-update-var) {

--- a/packages/theme/src/_mixins.scss
+++ b/packages/theme/src/_mixins.scss
@@ -169,6 +169,13 @@
       secondary-color,
       $rmd-theme-secondary-text-on-light-color
     );
+
+    @if $rmd-card-light-background-color != $rmd-card-dark-background-color {
+      @include rmd-card-theme-update-var(
+        background-color,
+        $rmd-card-light-background-color
+      );
+    }
   }
 
   @if mixin-exists(rmd-chip-theme-update-var) {
@@ -339,6 +346,13 @@
       secondary-color,
       $rmd-theme-secondary-text-on-dark-color
     );
+
+    @if $rmd-card-light-background-color != $rmd-card-dark-background-color {
+      @include rmd-card-theme-update-var(
+        background-color,
+        $rmd-card-dark-background-color
+      );
+    }
   }
 
   @if mixin-exists(rmd-chip-theme-update-var) {

--- a/packages/theme/src/_mixins.scss
+++ b/packages/theme/src/_mixins.scss
@@ -65,22 +65,127 @@
 /// `$rmd-theme-dark-class` variable to either set the styles with a media
 /// query or only when the dark class has been enabled on a parent element.
 ///
+/// Note: This will have a higher specificity than other variables so the colors
+/// might not be as expected. It is recommended to set a custom CSS variable
+/// instead of using this mixin.
+///
+/// @example scss - Simple Example
+///   $rmd-theme-dark-elevation: true;
+///   // OVERRIDE_VARIABLES
+///
+///   .container {
+///     @include rmd-theme-dark-elevation-styles {
+///       background-color: red;
+///     }
+///   }
+///
+///   @include rmd-theme-dark-elevation-styles($selector: null) {
+///     --container-bg: orange;
+///   }
+///
+///   @include rmd-theme-dark-elevation-styles($selector: '.rmd-menu') {
+///     --container-bg: blue;
+///   }
+///
+///   .container-2 {
+///     background-color: var(--container-bg, red);
+///   }
+///
+/// @example scss - Simple Prefers Color Scheme
+///   $rmd-theme-dark-elevation: true;
+///   $rmd-theme-dark-class: 'prefers-color-scheme';
+///   // OVERRIDE_VARIABLES
+///
+///   .container {
+///     @include rmd-theme-dark-elevation-styles {
+///       background-color: red;
+///     }
+///   }
+///
+///   @include rmd-theme-dark-elevation-styles($selector: ':root') {
+///     --container-bg: orange;
+///   }
+///
+///   @include rmd-theme-dark-elevation-styles($selector: '.rmd-menu') {
+///     --container-bg: blue;
+///   }
+///
+///   .container-2 {
+///     background-color: var(--container-bg, red);
+///   }
+///
+/// @example scss - CSS Module Example
+///   $rmd-theme-dark-elevation: true;
+///   // OVERRIDE_VARIABLES
+///
+///   .container {
+///     @include rmd-theme-dark-elevation-styles(true) {
+///       background-color: red;
+///     }
+///   }
+///
+///   @include rmd-theme-dark-elevation-styles(true, null) {
+///     --container-bg: orange;
+///   }
+///
+///   @include rmd-theme-dark-elevation-styles(true, '.rmd-menu') {
+///     --container-bg: blue;
+///   }
+///
+///   .container-2 {
+///     background-color: var(--container-bg, red);
+///   }
+///
+/// @example scss - CSS Module Prefers Color Scheme Example
+///   $rmd-theme-dark-elevation: true;
+///   $rmd-theme-dark-class: 'prefers-color-scheme';
+///   // OVERRIDE_VARIABLES
+///
+///   .container {
+///     @include rmd-theme-dark-elevation-styles(true) {
+///       background-color: red;
+///     }
+///   }
+///
+///   @include rmd-theme-dark-elevation-styles(true, ':root') {
+///     --container-bg: orange;
+///   }
+///
+///   @include rmd-theme-dark-elevation-styles(true, '.rmd-menu') {
+///     --container-bg: blue;
+///   }
+///
+///   .container-2 {
+///     background-color: var(--container-bg, red);
+///   }
+///
 /// @since 2.5.4
 /// @param {Boolean} css-modules [false] - Boolean if this is being used within
 /// CSS Modules which will update the selector to work correctly by wrapping
 /// different parts with `:global` and `:local`.
-@mixin rmd-theme-dark-elevation-styles($css-modules: false) {
+/// @param {String} selector ['&'] - An optional selector to use if the
+/// `$rmd-theme-dark-class` is `'prefers-color-scheme'`. Otherwise, setting this
+/// to a value other than `'&'` will be joined to the `$rmd-theme-dark-class`.
+@mixin rmd-theme-dark-elevation-styles($css-modules: false, $selector: '&') {
   @if $rmd-theme-dark-elevation {
     @if $rmd-theme-dark-class == 'prefers-color-scheme' {
       @media (prefers-color-scheme: dark) {
-        & {
+        #{$selector} {
           @content;
         }
       }
     } @else {
-      @include rmd-utils-optional-css-modules(
+      $parent-selector: $selector == '&';
+      $class-name: if(
+        $parent-selector or not $selector,
         $rmd-theme-dark-class,
-        $css-modules
+        $rmd-theme-dark-class + ' ' + $selector
+      );
+
+      @include rmd-utils-optional-css-modules(
+        $class-name,
+        $css-modules,
+        $parent-selector
       ) {
         @content;
       }
@@ -90,6 +195,30 @@
 
 /// This mixin should normally be used with the `rmd-elevation` mixin to change
 /// the background color based on the current elevation in dark themes.
+///
+/// Note: This will have a higher specificity than other variables so the colors
+/// might not be as expected. It is recommended to set a custom CSS variable
+/// instead of using this mixin.
+///
+/// @example scss - All z-values
+///   $rmd-theme-dark-elevation: true;
+///   // OVERRIDE_VARIABLES
+///
+///   .container {
+///     @for $i from 0 to 24 {
+///       @include rmd-theme-dark-elevation($i);
+///     }
+///   }
+///
+/// @example scss - All z-values with CSS Modules
+///   $rmd-theme-dark-elevation: true;
+///   // OVERRIDE_VARIABLES
+///
+///   .container {
+///     @for $i from 0 to 24 {
+///       @include rmd-theme-dark-elevation($i, true);
+///     }
+///   }
 ///
 /// @since 2.1.0
 /// @param {Number} z-value - This should be a number between 0 and 24

--- a/packages/theme/src/_mixins.scss
+++ b/packages/theme/src/_mixins.scss
@@ -231,6 +231,15 @@
       text-filled-color,
       $rmd-text-field-filled-light-background-color
     );
+
+    @if $rmd-listbox-light-background-color !=
+      $rmd-listbox-dark-background-color
+    {
+      @include rmd-form-theme-update-var(
+        listbox-background-color,
+        $rmd-listbox-light-background-color
+      );
+    }
   }
 
   @if mixin-exists(rmd-menu-theme-update-var) {
@@ -415,6 +424,15 @@
       text-filled-color,
       $rmd-text-field-filled-dark-background-color
     );
+
+    @if $rmd-listbox-light-background-color !=
+      $rmd-listbox-dark-background-color
+    {
+      @include rmd-form-theme-update-var(
+        listbox-background-color,
+        $rmd-listbox-dark-background-color
+      );
+    }
   }
 
   @if mixin-exists(rmd-menu-theme-update-var) {

--- a/packages/theme/src/_mixins.scss
+++ b/packages/theme/src/_mixins.scss
@@ -216,6 +216,15 @@
     );
   }
 
+  @if mixin-exists(rmd-menu-theme-update-var) {
+    @if $rmd-menu-light-background-color != $rmd-menu-dark-background-color {
+      @include rmd-menu-theme-update-var(
+        background-color,
+        $rmd-menu-light-background-color
+      );
+    }
+  }
+
   @if mixin-exists(rmd-states-theme-update-var) {
     @include rmd-states-theme-update-var(
       hover-color,
@@ -372,6 +381,15 @@
       text-filled-color,
       $rmd-text-field-filled-dark-background-color
     );
+  }
+
+  @if mixin-exists(rmd-menu-theme-update-var) {
+    @if $rmd-menu-light-background-color != $rmd-menu-dark-background-color {
+      @include rmd-menu-theme-update-var(
+        background-color,
+        $rmd-menu-dark-background-color
+      );
+    }
   }
 
   @if mixin-exists(rmd-states-theme-update-var) {

--- a/packages/theme/src/_mixins.scss
+++ b/packages/theme/src/_mixins.scss
@@ -211,6 +211,23 @@
     }
   }
 
+  @if mixin-exists(rmd-sheet-theme-update-var) {
+    @if $rmd-sheet-light-background-color != $rmd-sheet-dark-background-color {
+      @include rmd-sheet-theme-update-var(
+        background-color,
+        $rmd-sheet-light-background-color
+      );
+    }
+    @if $rmd-sheet-raised-light-background-color !=
+      $rmd-sheet-raised-dark-background-color
+    {
+      @include rmd-sheet-theme-update-var(
+        raised-background-color,
+        $rmd-sheet-raised-light-background-color
+      );
+    }
+  }
+
   @if mixin-exists(rmd-divider-theme-update-var) {
     @include rmd-divider-theme-update-var(
       background-color,
@@ -400,6 +417,23 @@
       @include rmd-dialog-theme-update-var(
         background-color,
         $rmd-dialog-dark-background-color
+      );
+    }
+  }
+
+  @if mixin-exists(rmd-sheet-theme-update-var) {
+    @if $rmd-sheet-light-background-color != $rmd-sheet-dark-background-color {
+      @include rmd-sheet-theme-update-var(
+        background-color,
+        $rmd-sheet-dark-background-color
+      );
+    }
+    @if $rmd-sheet-raised-light-background-color !=
+      $rmd-sheet-raised-dark-background-color
+    {
+      @include rmd-sheet-theme-update-var(
+        raised-background-color,
+        $rmd-sheet-raised-dark-background-color
       );
     }
   }


### PR DESCRIPTION
This adds a few fixes for the "Dark Theme Elevation" feature.

#### Color Change Warning

The sheet's color while raised was actually set to the wrong value when I first implemented the "Dark Theme Elevation" and it will appear lighter now. If you want to use the previous color for raised sheets, set the following variable before including `react-md` styles:

- `$rmd-sheet-raised-dark-background-color: map-get($rmd-theme-dark-elevation-colors, $rmd-sheet-elevation);`

## Description

1. Created a new `$rmd-toast-dark-elevation-background-color` variable
which can be set to `null` if the `background-color` should not change
when the dark theme is active.

2. Decreased the specificity for the dark theme elevation background
color so that it can be overridden more easily.

3. Updated the `@mixin rmd-theme-light` and `@mixin rmd-theme-dark` to
conditionally update the alert's background color when needed.


Alert theme example diff:

```diff
-.dark-theme .rmd-toast {
-  --rmd-theme-background: #2c2c2c;
-  background-color: var(--rmd-theme-background, #323232);
-}

 .dark-theme {
   --rmd-theme-background: #121212;
   --rmd-theme-surface: #424242;
   --rmd-theme-on-surface: #fff;
   --rmd-theme-text-primary-on-background: #d9d9d9;
   --rmd-theme-text-secondary-on-background: #b3b3b3;
   --rmd-theme-text-hint-on-background: gray;
   --rmd-theme-text-disabled-on-background: gray;
   --rmd-theme-text-icon-on-background: #b3b3b3;
+  --rmd-alert-background-color: #2c2c2c;
   --rmd-app-bar-default-color: #fff;
   --rmd-card-color: #d9d9d9;
 }
```

### New Dark Theme Elevation Variables

Setting these variables to `null` will disable this functionality.

- `$rmd-toast-dark-elevation-background-color`
- `$rmd-card-dark-elevation-background-color`
- `$rmd-dialog-dark-elevation-background-color`
- `$rmd-listbox-dark-elevation-background-color`
- `$rmd-menu-dark-elevation-background-color`
- `$rmd-sheet-dark-elevation-background-color`
- `$rmd-sheet-raised-dark-elevation-background-color:`

### Other New Variables

- `$rmd-card-light-background-color`
- `$rmd-card-dark-elevation-background-color`
- `$rmd-card-dark-background-color`
- `$rmd-dialog-light-background-color`
- `$rmd-dialog-dark-background-color`
- `$rmd-dialog-background-color`
- `$rmd-listbox-light-background-color`
- `$rmd-listbox-dark-background-color`
- `$rmd-listbox-background-color`
- `$rmd-menu-light-background-color`
- `$rmd-menu-dark-background-color`
- `$rmd-sheet-light-background-color`
- `$rmd-sheet-dark-background-color`
- `$rmd-sheet-background-color`
- `$rmd-sheet-raised-light-background-color`
- `$rmd-sheet-raised-dark-background-color`
- `$rmd-sheet-raised-background-color`


### Deprecated Variables

- `$rmd-card-dark-elevation-borrdered-background-color`

## New CSS Variables

- `--rmd-dialog-background-color`
- `--rmd-form-listbox-background-color`
- `--rmd-sheet-background-color`
- `--rmd-sheet-raised-background-color`

## Other Nodes

This actually ended up fixing some behavior if the `$rmd-theme-dark-class` is set to `'prefers-color-scheme'`.

Closes #1075 