### PR TITLE
Updated all ReactMD CSS Variables to appear under the same `:root`

### DIFF
--- a/packages/theme/src/_helpers.scss
+++ b/packages/theme/src/_helpers.scss
@@ -115,20 +115,37 @@
 
 ///
 /// @access private
+/// @since 2.7.2
+@mixin rmd-theme-create-css-variables(
+  $theme-map,
+  $theme-group,
+  $exclude: null
+) {
+  @each $theme-name, $theme-value in $theme-map {
+    @if $theme-value !=
+      null and
+      ($exclude == null or not index($exclude, $theme-name))
+    {
+      @include rmd-theme-update-rmd-var(
+        $theme-value,
+        $theme-name,
+        $theme-map,
+        $theme-group
+      );
+    }
+  }
+}
+
+///
+/// @access private
 @mixin rmd-theme-create-root-theme($theme-map, $theme-group, $exclude: null) {
-  :root {
-    @each $theme-name, $theme-value in $theme-map {
-      @if $theme-value !=
-        null and
-        ($exclude == null or not index($exclude, $theme-name))
-      {
-        @include rmd-theme-update-rmd-var(
-          $theme-value,
-          $theme-name,
-          $theme-map,
-          $theme-group
-        );
-      }
+  @if not $rmd-utils-group-css-variables {
+    :root {
+      @include rmd-theme-create-css-variables(
+        $theme-map,
+        $theme-group,
+        $exclude
+      );
     }
   }
 }

--- a/packages/utils/src/_mixins.scss
+++ b/packages/utils/src/_mixins.scss
@@ -705,6 +705,155 @@
   }
 }
 
+/// @since 2.7.2
+/// @access private
+@mixin rmd-utils-create-css-variables {
+  @if variable-exists(rmd-theme-values) {
+    @include rmd-theme-create-css-variables($rmd-theme-values, theme);
+  }
+
+  @if variable-exists(rmd-typography-theme-values) {
+    @include rmd-theme-create-css-variables(
+      $rmd-typography-theme-values,
+      typography
+    );
+  }
+
+  @if variable-exists(rmd-states-theme-values) {
+    @include rmd-theme-create-css-variables($rmd-states-theme-values, states);
+  }
+
+  @if variable-exists(rmd-tooltip-theme-values) {
+    @include rmd-theme-create-css-variables($rmd-tooltip-theme-values, tooltip);
+  }
+
+  @if variable-exists(rmd-divider-theme-values) {
+    @include rmd-theme-create-css-variables($rmd-divider-theme-values, divider);
+  }
+
+  @if variable-exists(rmd-icon-theme-values) {
+    @include rmd-theme-create-css-variables($rmd-icon-theme-values, icon);
+  }
+
+  @if variable-exists(rmd-avatar-theme-values) {
+    @include rmd-theme-create-css-variables($rmd-avatar-theme-values, avatar);
+  }
+
+  @if variable-exists(rmd-link-theme-values) {
+    @include rmd-theme-create-css-variables($rmd-link-theme-values, link);
+  }
+
+  @if variable-exists(rmd-overlay-theme-values) {
+    @include rmd-theme-create-css-variables($rmd-overlay-theme-values, overlay);
+  }
+
+  @if variable-exists(rmd-progress-theme-values) {
+    @include rmd-theme-create-css-variables(
+      $rmd-progress-theme-values,
+      progress
+    );
+  }
+
+  @if variable-exists(rmd-button-theme-values) {
+    @include rmd-theme-create-css-variables($rmd-button-theme-values, button);
+  }
+
+  @if variable-exists(rmd-badge-theme-values) {
+    @include rmd-theme-create-css-variables($rmd-badge-theme-values, badge);
+  }
+
+  @if variable-exists(rmd-chip-theme-values) {
+    @include rmd-theme-create-css-variables($rmd-chip-theme-values, chip);
+  }
+
+  @if variable-exists(rmd-alert-theme-values) {
+    @include rmd-theme-create-css-variables($rmd-alert-theme-values, alert);
+  }
+
+  @if variable-exists(rmd-app-bar-theme-values) {
+    @include rmd-theme-create-css-variables($rmd-app-bar-theme-values, app-bar);
+  }
+
+  @if variable-exists(rmd-card-theme-values) {
+    @include rmd-theme-create-css-variables($rmd-card-theme-values, card);
+  }
+
+  @if variable-exists(rmd-expansion-panel-theme-values) {
+    @include rmd-theme-create-css-variables(
+      $rmd-expansion-panel-theme-values,
+      expansion-panel
+    );
+  }
+
+  @if variable-exists(rmd-list-theme-values) {
+    @include rmd-theme-create-css-variables($rmd-list-theme-values, list);
+  }
+
+  @if variable-exists(rmd-dialog-theme-values) {
+    @include rmd-theme-create-css-variables($rmd-dialog-theme-values, dialog);
+  }
+
+  @if variable-exists(rmd-menu-theme-values) {
+    @include rmd-theme-create-css-variables($rmd-menu-theme-values, menu);
+  }
+
+  @if variable-exists(rmd-sheet-theme-values) {
+    $exclude: if(
+      $rmd-theme-dark-elevation,
+      (),
+      (background-color, raised-background-color)
+    );
+
+    @include rmd-theme-create-css-variables(
+      $rmd-sheet-theme-values,
+      sheet,
+      $exclude
+    );
+  }
+
+  @if variable-exists(rmd-tabs-theme-values) {
+    @include rmd-theme-create-css-variables($rmd-tabs-theme-values, tabs);
+  }
+
+  @if variable-exists(rmd-tree-theme-values) {
+    @include rmd-theme-create-css-variables($rmd-tree-theme-values, tree);
+  }
+
+  @if variable-exists(rmd-table-theme-values) {
+    @include rmd-theme-create-css-variables($rmd-table-theme-values, table);
+  }
+
+  @if variable-exists(rmd-form-theme-values) {
+    $exclude: (
+      addon-top
+        label-left-offset
+        label-top-offset
+        label-active-background-color
+        label-active-padding
+        text-offset
+        text-padding-left
+        text-padding-right
+        text-padding-top
+    );
+
+    @include rmd-theme-create-css-variables(
+      $rmd-form-theme-values,
+      form,
+      $exclude
+    );
+  }
+
+  @if variable-exists(rmd-layout-theme-values) {
+    @include rmd-theme-create-css-variables($rmd-layout-theme-values, layout);
+  }
+
+  @if $rmd-utils-auto-dense {
+    @include rmd-utils-desktop-media {
+      @include rmd-utils-dense;
+    }
+  }
+}
+
 /// This mixin will attempt to apply all the available dense theme mixins that have
 /// been imported. This should normally be used within a `:root` selector and a media
 /// query.
@@ -748,6 +897,14 @@
 @mixin react-md-utils {
   @include rmd-utils-base;
   @include react-md-utils-grid;
+
+  @if $rmd-utils-group-css-variables and
+    mixin-exists(rmd-theme-create-css-variables)
+  {
+    :root {
+      @include rmd-utils-create-css-variables;
+    }
+  }
 
   // the mixins are added in this specific order to make overriding easier
   @if mixin-exists(react-md-theme) {
@@ -862,7 +1019,7 @@
     @include react-md-layout;
   }
 
-  @if $rmd-utils-auto-dense {
+  @if $rmd-utils-auto-dense and not $rmd-utils-group-css-variables {
     :root {
       @include rmd-utils-desktop-media {
         @include rmd-utils-dense;

--- a/packages/utils/src/_variables.scss
+++ b/packages/utils/src/_variables.scss
@@ -50,6 +50,17 @@ $rmd-utils-skip-validation: false !default;
 /// @type Boolean
 $rmd-utils-fix-moz-focus: true !default;
 
+/// This feature flag will make it so that all the rmd css variables are grouped
+/// together under the same `:root` element to make debugging easier through the
+/// dev-tools. If this causes issues for some reason, set this value to `false`
+/// to have the existing behavior.
+///
+/// Note: If no bugs are reported, this will be the default behavior in the next
+/// major release and no longer a feature flag.
+/// @type Boolean
+/// @since 2.7.2
+$rmd-utils-group-css-variables: true !default;
+
 /// The max width for a phone when in portrait or landscape mode.
 /// @type Number
 $rmd-utils-phone-max-width: 47.9375em !default;


### PR DESCRIPTION
## Description

This change makes it so that all the ReactMD theme CSS variables are grouped under a single `:root` element instead of each having their own `:root`. This is mostly to help clean up the dev-tools and figure out what CSS variables are created by this library.

This is going to be enabled by default going forward but can be disabled by setting `$rmd-utils-group-css-variables: false;` with your other global overrides.

To get a better explanation of the change, click the images below to see a video of the DevTools changes.

### Before

[![CSS Variables in DevTools - Before](https://img.youtube.com/vi/hi02cx1eysE/0.jpg)](https://www.youtube.com/watch?v=hi02cx1eysE "CSS Variables in DevTools (Before)")

### After

[![CSS Variables in DevTools - After](https://img.youtube.com/vi/bjhKSrcX1NM/0.jpg)](https://www.youtube.com/watch?v=bjhKSrcX1NM "CSS Variables in DevTools (After)")

## Notes

There is a _slight_ bundle size increase with this change, so still not entirely sure if I will merge this or if this is a desired change.

```sh
$ yarn dev-utils libsize --force-themes --no-umd
yarn run v1.22.10
$ dev-utils libsize --force-themes --no-umd
yarn dev-utils libsize

The min and max gzipped CSS bundle sizes are:
 - themes/react-md.grey-red-700-light.min.css 17.35 KB (+ 0.10 KB)
 - themes/react-md.lime-teal-200-dark.min.css 17.42 KB (+ 0.10 KB)
```