### PR TITLE
feat(typescript): support typescript version to v4.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "react-test-renderer": "^17.0.2",
     "sass-lint": "^1.13.1",
     "ts-jest": "^26.5.4",
-    "typescript": "^4.1.5"
+    "typescript": "^4.2.4"
   },
   "lint-staged": {
     "**/*.{js,jsx,md}": [

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -40,8 +40,8 @@
     "prompts": "^2.4.1",
     "rimraf": "^3.0.2",
     "sassdoc": "^2.7.2",
-    "ts-morph": "^9.1.0",
-    "typescript": "^4.1.5"
+    "ts-morph": "^10.0.2",
+    "typescript": "^4.2.4"
   },
   "devDependencies": {
     "@types/cssnano": "^4.0.0",

--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -102,7 +102,7 @@
     "npm-run-all": "^4.1.5",
     "raw-loader": "^4.0.2",
     "ts-node": "^9.1.1",
-    "typescript": "^4.1.5",
+    "typescript": "^4.2.4",
     "webpack": "^5.32.0"
   }
 }

--- a/packages/form/src/text-field/__tests__/TextArea.tsx
+++ b/packages/form/src/text-field/__tests__/TextArea.tsx
@@ -3,13 +3,13 @@
 import React, { ReactElement, useState } from "react";
 import { act, fireEvent, render } from "@testing-library/react";
 import { mocked } from "ts-jest/utils";
-import ResizeObserverPolyfill from "resize-observer-polyfill";
+import { ResizeObserver } from "@juggle/resize-observer";
 
 import { TextArea } from "../TextArea";
 
-jest.mock("resize-observer-polyfill");
+jest.mock("@juggle/resize-observer");
 
-const ResizeObserverMock = mocked(ResizeObserverPolyfill);
+const ResizeObserverMock = mocked(ResizeObserver);
 const DEFAULT_DOM_RECT: DOMRectReadOnly = {
   x: 0,
   y: 0,
@@ -57,7 +57,12 @@ class MockedObserver implements ResizeObserver {
 
     act(() => {
       this._callback(
-        this._elements.map((target) => ({ target, contentRect })),
+        this._elements.map((target) => ({
+          target,
+          contentRect,
+          borderBoxSize: [],
+          contentBoxSize: [],
+        })),
         this
       );
     });
@@ -68,6 +73,7 @@ describe("TextArea", () => {
   let observer: MockedObserver | undefined;
   beforeAll(() => {
     ResizeObserverMock.mockImplementation((callback) => {
+      // @ts-ignore
       observer = new MockedObserver(callback);
       return observer;
     });

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -40,8 +40,8 @@
     "access": "public"
   },
   "dependencies": {
-    "classnames": "^2.3.1",
-    "resize-observer-polyfill": "^1.5.1"
+    "@juggle/resize-observer": "^3.3.0",
+    "classnames": "^2.3.1"
   },
   "devDependencies": {
     "react": "^17.0.2",

--- a/packages/utils/src/layout/__tests__/GridList.tsx
+++ b/packages/utils/src/layout/__tests__/GridList.tsx
@@ -1,15 +1,15 @@
 /* eslint-disable no-underscore-dangle */
 import React from "react";
 import { act, render } from "@testing-library/react";
-import ResizeObserverPolyfill from "resize-observer-polyfill";
+import { ResizeObserver } from "@juggle/resize-observer";
 import { mocked } from "ts-jest/utils";
 
 import { GridList } from "../GridList";
 import { useGridListSize } from "../useGridList";
 
-jest.mock("resize-observer-polyfill");
+jest.mock("@juggle/resize-observer");
 
-const ResizeObserverMock = mocked(ResizeObserverPolyfill);
+const ResizeObserverMock = mocked(ResizeObserver);
 
 const DEFAULT_DOM_RECT: DOMRectReadOnly = {
   x: 100,
@@ -53,7 +53,12 @@ class MockedObserver implements ResizeObserver {
 
     act(() => {
       this._callback(
-        this._elements.map((target) => ({ target, contentRect })),
+        this._elements.map((target) => ({
+          target,
+          contentRect,
+          borderBoxSize: [],
+          contentBoxSize: [],
+        })),
         this
       );
     });
@@ -64,6 +69,7 @@ let observer: MockedObserver | undefined;
 let getBoundingClientRect: jest.SpyInstance<DOMRect, []>;
 beforeAll(() => {
   ResizeObserverMock.mockImplementation((callback) => {
+    // @ts-ignore
     observer = new MockedObserver(callback);
     return observer;
   });

--- a/packages/utils/src/sizing/__tests__/useResizeObserver.tsx
+++ b/packages/utils/src/sizing/__tests__/useResizeObserver.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 import React, { useRef } from "react";
 import { act, render } from "@testing-library/react";
-import ResizeObserverPolyfill from "resize-observer-polyfill";
+import { ResizeObserver } from "@juggle/resize-observer";
 import { mocked } from "ts-jest/utils";
 
 import {
@@ -10,9 +10,9 @@ import {
   useResizeObserver,
 } from "../useResizeObserver";
 
-jest.mock("resize-observer-polyfill");
+jest.mock("@juggle/resize-observer");
 
-const ResizeObserverMock = mocked(ResizeObserverPolyfill);
+const ResizeObserverMock = mocked(ResizeObserver);
 const observe = jest.fn();
 const unobserve = jest.fn();
 const disconnect = jest.fn();
@@ -62,7 +62,12 @@ class MockedObserver implements ResizeObserver {
 
     act(() => {
       this._callback(
-        this._elements.map((target) => ({ target, contentRect })),
+        this._elements.map((target) => ({
+          target,
+          contentRect,
+          borderBoxSize: [],
+          contentBoxSize: [],
+        })),
         this
       );
     });
@@ -78,7 +83,10 @@ class MockedObserver implements ResizeObserver {
         throw new Error("Unable to find triggerable element");
       }
 
-      this._callback([{ target, contentRect }], this);
+      this._callback(
+        [{ target, contentRect, borderBoxSize: [], contentBoxSize: [] }],
+        this
+      );
     });
   }
 }
@@ -87,6 +95,7 @@ describe("useResizeObserver", () => {
   let observer: MockedObserver | undefined;
   beforeAll(() => {
     ResizeObserverMock.mockImplementation((callback) => {
+      // @ts-ignore
       observer = new MockedObserver(callback);
       return observer;
     });

--- a/packages/utils/src/sizing/useResizeObserver.ts
+++ b/packages/utils/src/sizing/useResizeObserver.ts
@@ -1,5 +1,5 @@
 import { Ref } from "react";
-import ResizeObserverPolyfill from "resize-observer-polyfill";
+import { ResizeObserver } from "@juggle/resize-observer";
 
 import { EnsuredRefs, useEnsuredRef } from "../useEnsuredRef";
 import { useIsomorphicLayoutEffect } from "../useIsomorphicLayoutEffect";
@@ -123,7 +123,7 @@ function isWidthChange(
  * @see https://github.com/WICG/resize-observer/issues/59
  * @internal
  */
-let sharedObserver: ResizeObserverPolyfill | undefined;
+let sharedObserver: ResizeObserver | undefined;
 
 /**
  *
@@ -142,7 +142,7 @@ function init(): void {
     return;
   }
 
-  sharedObserver = new ResizeObserverPolyfill((entries) => {
+  sharedObserver = new ResizeObserver((entries) => {
     // Note: might need to wait until an requestAnimationFrame has completed to
     // fix the resize observer loop exceeded error if switching to
     // `useIsomorphicLayoutEffect` and a shared observer didn't fix that error:

--- a/packages/utils/src/sizing/useResizeObserverV1.ts
+++ b/packages/utils/src/sizing/useResizeObserverV1.ts
@@ -1,5 +1,5 @@
 import { MutableRefObject, useEffect } from "react";
-import ResizeObserverPolyfill from "resize-observer-polyfill";
+import { ResizeObserver } from "@juggle/resize-observer";
 
 /**
  * A function that will return the resize observer target element. This should
@@ -201,7 +201,7 @@ export function useResizeObserverV1<E extends HTMLElement>({
     }
 
     let prevSize: ElementSize | undefined;
-    const observer = new ResizeObserverPolyfill((entries) => {
+    const observer = new ResizeObserver((entries) => {
       for (let i = 0; i < entries.length; i += 1) {
         const entry = entries[i];
         const target = entry.target as HTMLElement;

--- a/yarn.lock
+++ b/yarn.lock
@@ -392,14 +392,6 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
-"@dsherret/to-absolute-glob@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz#1f6475dc8bd974cea07a2daf3864b317b1dd332c"
-  integrity sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=
-  dependencies:
-    is-absolute "^1.0.0"
-    is-negated-glob "^1.0.0"
-
 "@eslint/eslintrc@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.0.tgz#99cc0a0584d72f1df38b900fb062ba995f395547"
@@ -1703,17 +1695,14 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
-"@ts-morph/common@~0.7.0":
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/@ts-morph/common/-/common-0.7.2.tgz#b937d13376695146735aecec6af4573cee513a56"
-  integrity sha512-XyUPLf1UHtteP5C5FEgVJqgIEOcmaSEoJyU/jQ1gTBKlz/lb1Uss4ix+D2e5qRwPFiBMqM/jwJpna0yVDE5V/g==
+"@ts-morph/common@~0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@ts-morph/common/-/common-0.9.0.tgz#a306355bad82cff22a1881f7f2f2c710bbb4d69d"
+  integrity sha512-yPcW6koNVK1hVKUu+KhPzhfgMb0uwzr2FewF+q8kxLerl0b+YZwmjvFMU2qbIawytIHT2VBI4bi+C09EFPB4aw==
   dependencies:
-    "@dsherret/to-absolute-glob" "^2.0.2"
-    fast-glob "^3.2.4"
-    is-negated-glob "^1.0.0"
+    fast-glob "^3.2.5"
+    minimatch "^3.0.4"
     mkdirp "^1.0.4"
-    multimatch "^5.0.0"
-    typescript "~4.1.2"
 
 "@types/adm-zip@^0.4.33":
   version "0.4.33"
@@ -6206,10 +6195,10 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
   integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
 
-fast-glob@^3.1.1, fast-glob@^3.2.4:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.4.tgz#d20aefbf99579383e7f3cc66529158c9b98554d3"
-  integrity sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==
+fast-glob@^3.1.1, fast-glob@^3.2.5:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.5.tgz#7939af2a656de79a4f1901903ee8adcaa7cb9661"
+  integrity sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -14865,13 +14854,12 @@ ts-jest@^26.5.4:
     semver "7.x"
     yargs-parser "20.x"
 
-ts-morph@^9.1.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/ts-morph/-/ts-morph-9.1.0.tgz#10d2088387c71f3c674f82492a3cec1e3538f0dd"
-  integrity sha512-sei4u651MBenr27sD6qLDXN3gZ4thiX71E3qV7SuVtDas0uvK2LtgZkIYUf9DKm/fLJ6AB/+yhRJ1vpEBJgy7Q==
+ts-morph@^10.0.2:
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/ts-morph/-/ts-morph-10.0.2.tgz#292418207db467326231b2be92828b5e295e7946"
+  integrity sha512-TVuIfEqtr9dW25K3Jajqpqx7t/zLRFxKu2rXQZSDjTm4MO4lfmuj1hn8WEryjeDDBFcNOCi+yOmYUYR4HucrAg==
   dependencies:
-    "@dsherret/to-absolute-glob" "^2.0.2"
-    "@ts-morph/common" "~0.7.0"
+    "@ts-morph/common" "~0.9.0"
     code-block-writer "^10.1.1"
 
 ts-node@^9.1.1:
@@ -15019,10 +15007,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.1.5, typescript@~4.1.2:
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
-  integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
+typescript@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
+  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
 
 uglify-js@3.4.x, uglify-js@^3.1.4:
   version "3.4.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -621,6 +621,11 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@juggle/resize-observer@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.3.0.tgz#2e7a2935adbfae46f9efbd1e1455254ee7ea2219"
+  integrity sha512-P1v2nvK7z2gOLVM/bveIRLG9L99uEahTGgTltyF03zixZAjI9YmKLj5Z9MpS9wBIUt5WDoQORT2lXvLOIF89iA==
+
 "@lerna/add@4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-4.0.0.tgz#c36f57d132502a57b9e7058d1548b7a565ef183f"
@@ -13061,11 +13066,6 @@ require-uncached@^1.0.2:
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
-
-resize-observer-polyfill@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
-  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This _might_ be a breaking change for typescript consumers since they might also need to update their typescript version to v4.2.3 or whatever version added the type definitions for `ResizeObserver`.

This also changed the `resize-observer-polyfill` dependency to `@juggle/resize-observer` since `resize-observer-polyfill` hasn't been updated since 2018 and the type definitions cause issues with the `lib.d.ts` definitions now provided for the `ResizeObserver`.