### PR TITLE
fix(layout): non-fixed AppBar mini layouts

### DIFF
--- a/packages/documentation/src/components/Demos/Layout/NonFixedAppBarLayouts.md
+++ b/packages/documentation/src/components/Demos/Layout/NonFixedAppBarLayouts.md
@@ -1,0 +1,12 @@
+Since you might not want to always have the `AppBar` fixed to the top of the
+page for your layout, you can remove the fixed behavior by setting
+`fixed: false` with the `appBarProps` prop:
+
+```tsx
+<Layout {...props} appBarProps={{ fixed: false }}>
+  {children}
+</Layout>
+```
+
+The example below will showcase this type of layout along with the
+`temporary-mini` layout.

--- a/packages/documentation/src/components/Demos/Layout/NonFixedAppBarLayouts.tsx
+++ b/packages/documentation/src/components/Demos/Layout/NonFixedAppBarLayouts.tsx
@@ -1,0 +1,189 @@
+import React, { ReactElement, useState } from "react";
+import {
+  HomeSVGIcon,
+  ShareSVGIcon,
+  StarSVGIcon,
+} from "@react-md/material-icons";
+import {
+  Layout,
+  LayoutNavigationTree,
+  useLayoutNavigation,
+} from "@react-md/layout";
+import { CrossFade } from "@react-md/transition";
+import { Text, TextContainer } from "@react-md/typography";
+
+const navItems: LayoutNavigationTree = {
+  "/": {
+    itemId: "/",
+    parentId: null,
+    children: "Home",
+    leftAddon: <HomeSVGIcon />,
+  },
+  "/route-1": {
+    itemId: "/route-1",
+    parentId: null,
+    children: "Route 1",
+    leftAddon: <StarSVGIcon />,
+  },
+  "/divider-1": {
+    itemId: "/divider-1",
+    parentId: null,
+    divider: true,
+    isCustom: true,
+  },
+  "/route-2": {
+    itemId: "/route-2",
+    parentId: null,
+    children: "Route 2",
+    leftAddon: <ShareSVGIcon />,
+  },
+};
+
+export default function NonFixedAppBarLayouts(): ReactElement | null {
+  const [selectedId, setSelectedId] = useState("/");
+  return (
+    <Layout
+      id="non-fixed-app-bar-layout"
+      title="Non-fixed AppBar Layout Title"
+      navHeaderTitle="Another Title"
+      phoneLayout="temporary-mini"
+      tabletLayout="temporary-mini"
+      landscapeTabletLayout="temporary-mini"
+      desktopLayout="temporary-mini"
+      appBarProps={{ fixed: false }}
+      treeProps={{
+        ...useLayoutNavigation(navItems, selectedId),
+        onItemSelect: setSelectedId,
+      }}
+      // setting `component: "div"` is only required since I already have a main
+      // element due to the documentation site's Layout component
+      mainProps={{ component: "div", style: { padding: "1rem" } }}
+    >
+      {/* just add an animation so it _looks_ like something happens */}
+      <CrossFade key={selectedId}>
+        <TextContainer>
+          <Text>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat. Duis aute irure dolor in
+            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+            pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+            culpa qui officia deserunt mollit anim id est laborum.
+          </Text>
+          <Text>
+            Sed ut perspiciatis unde omnis iste natus error sit voluptatem
+            accusantium doloremque laudantium, totam rem aperiam, eaque ipsa
+            quae ab illo inventore veritatis et quasi architecto beatae vitae
+            dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit
+            aspernatur aut odit aut fugit, sed quia consequuntur magni dolores
+            eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est,
+            qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit,
+            sed quia non numquam eius modi tempora incidunt ut labore et dolore
+            magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis
+            nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut
+            aliquid ex ea commodi consequatur? Quis autem vel eum iure
+            reprehenderit qui in ea voluptate velit esse quam nihil molestiae
+            consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla
+            pariatur?
+          </Text>
+          <Text>
+            At vero eos et accusamus et iusto odio dignissimos ducimus qui
+            blanditiis praesentium voluptatum deleniti atque corrupti quos
+            dolores et quas molestias excepturi sint occaecati cupiditate non
+            provident, similique sunt in culpa qui officia deserunt mollitia
+            animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis
+            est et expedita distinctio. Nam libero tempore, cum soluta nobis est
+            eligendi optio cumque nihil impedit quo minus id quod maxime placeat
+            facere possimus, omnis voluptas assumenda est, omnis dolor
+            repellendus. Temporibus autem quibusdam et aut officiis debitis aut
+            rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint
+            et molestiae non recusandae. Itaque earum rerum hic tenetur a
+            sapiente delectus, ut aut reiciendis voluptatibus maiores alias
+            consequatur aut perferendis doloribus asperiores repellat.
+          </Text>
+          <Text>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat. Duis aute irure dolor in
+            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+            pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+            culpa qui officia deserunt mollit anim id est laborum.
+          </Text>
+          <Text>
+            Sed ut perspiciatis unde omnis iste natus error sit voluptatem
+            accusantium doloremque laudantium, totam rem aperiam, eaque ipsa
+            quae ab illo inventore veritatis et quasi architecto beatae vitae
+            dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit
+            aspernatur aut odit aut fugit, sed quia consequuntur magni dolores
+            eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est,
+            qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit,
+            sed quia non numquam eius modi tempora incidunt ut labore et dolore
+            magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis
+            nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut
+            aliquid ex ea commodi consequatur? Quis autem vel eum iure
+            reprehenderit qui in ea voluptate velit esse quam nihil molestiae
+            consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla
+            pariatur?
+          </Text>
+          <Text>
+            At vero eos et accusamus et iusto odio dignissimos ducimus qui
+            blanditiis praesentium voluptatum deleniti atque corrupti quos
+            dolores et quas molestias excepturi sint occaecati cupiditate non
+            provident, similique sunt in culpa qui officia deserunt mollitia
+            animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis
+            est et expedita distinctio. Nam libero tempore, cum soluta nobis est
+            eligendi optio cumque nihil impedit quo minus id quod maxime placeat
+            facere possimus, omnis voluptas assumenda est, omnis dolor
+            repellendus. Temporibus autem quibusdam et aut officiis debitis aut
+            rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint
+            et molestiae non recusandae. Itaque earum rerum hic tenetur a
+            sapiente delectus, ut aut reiciendis voluptatibus maiores alias
+            consequatur aut perferendis doloribus asperiores repellat.
+          </Text>
+          <Text>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat. Duis aute irure dolor in
+            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+            pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+            culpa qui officia deserunt mollit anim id est laborum.
+          </Text>
+          <Text>
+            Sed ut perspiciatis unde omnis iste natus error sit voluptatem
+            accusantium doloremque laudantium, totam rem aperiam, eaque ipsa
+            quae ab illo inventore veritatis et quasi architecto beatae vitae
+            dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit
+            aspernatur aut odit aut fugit, sed quia consequuntur magni dolores
+            eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est,
+            qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit,
+            sed quia non numquam eius modi tempora incidunt ut labore et dolore
+            magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis
+            nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut
+            aliquid ex ea commodi consequatur? Quis autem vel eum iure
+            reprehenderit qui in ea voluptate velit esse quam nihil molestiae
+            consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla
+            pariatur?
+          </Text>
+          <Text>
+            At vero eos et accusamus et iusto odio dignissimos ducimus qui
+            blanditiis praesentium voluptatum deleniti atque corrupti quos
+            dolores et quas molestias excepturi sint occaecati cupiditate non
+            provident, similique sunt in culpa qui officia deserunt mollitia
+            animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis
+            est et expedita distinctio. Nam libero tempore, cum soluta nobis est
+            eligendi optio cumque nihil impedit quo minus id quod maxime placeat
+            facere possimus, omnis voluptas assumenda est, omnis dolor
+            repellendus. Temporibus autem quibusdam et aut officiis debitis aut
+            rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint
+            et molestiae non recusandae. Itaque earum rerum hic tenetur a
+            sapiente delectus, ut aut reiciendis voluptatibus maiores alias
+            consequatur aut perferendis doloribus asperiores repellat.
+          </Text>
+        </TextContainer>
+      </CrossFade>
+    </Layout>
+  );
+}

--- a/packages/documentation/src/components/Demos/Layout/index.tsx
+++ b/packages/documentation/src/components/Demos/Layout/index.tsx
@@ -9,6 +9,9 @@ import configurableLayout from "./ConfigurableLayout.md";
 import ControllingTheLayout from "./ControllingTheLayout";
 import controllingTheLayout from "./ControllingTheLayout.md";
 
+import NonFixedAppBarLayouts from "./NonFixedAppBarLayouts";
+import nonFixedAppBarLayouts from "./NonFixedAppBarLayouts.md";
+
 const modalProps = {
   fullPage: true,
   fullPageFAB: true,
@@ -31,6 +34,12 @@ const demos = [
     name: "Controlling the Layout",
     description: controllingTheLayout,
     children: <ControllingTheLayout />,
+  },
+  {
+    ...modalProps,
+    name: "Non-Fixed App Bar Layouts",
+    description: nonFixedAppBarLayouts,
+    children: <NonFixedAppBarLayouts />,
   },
 ];
 

--- a/packages/layout/src/Layout.tsx
+++ b/packages/layout/src/Layout.tsx
@@ -249,6 +249,9 @@ export function Layout({
   return (
     <LayoutProvider
       baseId={id}
+      fixedAppBar={
+        props.appBarProps?.fixed ?? typeof props.appBar === "undefined"
+      }
       phoneLayout={phoneLayout}
       tabletLayout={tabletLayout}
       landscapeTabletLayout={landscapeTabletLayout}

--- a/packages/layout/src/LayoutChildren.tsx
+++ b/packages/layout/src/LayoutChildren.tsx
@@ -1,4 +1,10 @@
-import React, { ReactElement, ReactNode, useEffect, useState } from "react";
+import React, {
+  HTMLAttributes,
+  ReactElement,
+  ReactNode,
+  useEffect,
+  useState,
+} from "react";
 import { SkipToMainContent, SkipToMainContentProps } from "@react-md/link";
 import { BaseTreeItem, TreeData } from "@react-md/tree";
 import { PropsWithRef } from "@react-md/utils";
@@ -8,6 +14,7 @@ import { LayoutAppBar } from "./LayoutAppBar";
 import { LayoutMain, LayoutMainProps } from "./LayoutMain";
 import { LayoutNavigation } from "./LayoutNavigation";
 import { useLayoutConfig } from "./LayoutProvider";
+import { MiniLayoutWrapper } from "./MiniLayoutWrapper";
 import { LayoutNavigationItem } from "./types";
 import { isMiniLayout } from "./utils";
 
@@ -61,6 +68,23 @@ export interface LayoutChildrenProps<
   miniNavItems?: TreeData<T>;
 
   /**
+   * This prop allows you to provide additional props to the `<div>` surrounding
+   * the `LayoutMain` and mini `LayoutNavigation` components.
+   *
+   * Note: This additional `<div>` will only be rendered if:
+   * - the current layout is one of the `mini` types
+   * - the layout is not using a fixed app bar
+   * - the `miniNav` prop has not been defined
+   * - `treeProps` have been provided
+   *
+   * @remarks \@since 2.8.3
+   */
+  miniWrapperProps?: PropsWithRef<
+    HTMLAttributes<HTMLDivElement>,
+    HTMLDivElement
+  >;
+
+  /**
    * The children to display within the layout. This is pretty much required
    * since you'll have an empty app otherwise, but it's left as optional just
    * for prototyping purposes.
@@ -88,8 +112,9 @@ export function LayoutChildren({
   navToggleProps,
   navAfterAppBar = false,
   nav: propNav,
-  miniNav: propMiniNav,
+  miniNav,
   miniNavItems,
+  miniWrapperProps,
   navHeader,
   navHeaderProps,
   navHeaderTitle,
@@ -151,48 +176,36 @@ export function LayoutChildren({
     );
   }
 
-  let miniNav = propMiniNav;
-  if (mini && treeProps && typeof miniNav === "undefined") {
-    let miniTreeProps = treeProps;
-    if (miniNavItems) {
-      miniTreeProps = {
-        ...miniTreeProps,
-        navItems: miniNavItems,
-      };
-    }
-
-    miniNav = (
-      <LayoutNavigation
-        header={navHeader}
-        headerProps={navHeaderProps}
-        headerTitle={navHeaderTitle}
-        headerTitleProps={navHeaderTitleProps}
-        closeNav={closeNav}
-        closeNavProps={closeNavProps}
-        treeProps={miniTreeProps}
-        {...navProps}
-        mini
-        hidden={miniHidden}
-      />
-    );
-  }
-
   return (
     <>
       <SkipToMainContent {...skipProps} mainId={mainId} />
       {navAfterAppBar && appBar}
       {nav}
       {!navAfterAppBar && appBar}
-      {/* mini nav should always be in tab index after app bar */}
-      {miniNav}
-      <LayoutMain
-        headerOffset={fixedAppBar}
-        {...mainProps}
-        id={mainId}
+      <MiniLayoutWrapper
         mini={mini}
+        miniNav={miniNav}
+        miniHidden={miniHidden}
+        containerProps={miniWrapperProps}
+        miniNavItems={miniNavItems}
+        treeProps={treeProps}
+        header={navHeader}
+        headerProps={navHeaderProps}
+        headerTitle={navHeaderTitle}
+        headerTitleProps={navHeaderTitleProps}
+        closeNav={closeNav}
+        closeNavProps={closeNavProps}
       >
-        {children}
-      </LayoutMain>
+        <LayoutMain
+          headerOffset={fixedAppBar}
+          mini={mini}
+          miniHidden={miniHidden}
+          {...mainProps}
+          id={mainId}
+        >
+          {children}
+        </LayoutMain>
+      </MiniLayoutWrapper>
     </>
   );
 }

--- a/packages/layout/src/LayoutChildren.tsx
+++ b/packages/layout/src/LayoutChildren.tsx
@@ -103,8 +103,7 @@ export function LayoutChildren({
   children,
 }: LayoutChildrenProps): ReactElement {
   const mainId = mainProps?.id || `${id}-main`;
-  const fixedAppBar = appBarProps?.fixed ?? typeof propAppBar === "undefined";
-  const { layout, visible } = useLayoutConfig();
+  const { layout, visible, fixedAppBar } = useLayoutConfig();
   const mini = isMiniLayout(layout);
   const [miniHidden, setMiniHidden] = useState(visible);
   // when the layout changes, the hidden state for the mini drawer must also be

--- a/packages/layout/src/LayoutMain.tsx
+++ b/packages/layout/src/LayoutMain.tsx
@@ -7,7 +7,7 @@ import { bem, useIsUserInteractionMode } from "@react-md/utils";
 
 import { DEFAULT_LAYOUT_MAIN_CLASSNAMES } from "./constants";
 import { useLayoutConfig } from "./LayoutProvider";
-import { isTemporaryLayout } from "./utils";
+import { isTemporaryLayout, isToggleableLayout } from "./utils";
 
 export interface LayoutMainProps extends HTMLAttributes<HTMLDivElement> {
   /**
@@ -37,6 +37,16 @@ export interface LayoutMainProps extends HTMLAttributes<HTMLDivElement> {
    * @remarks \@since 2.7.0
    */
   mini?: boolean;
+
+  /**
+   * Boolean if the mini layout is currently hidden to help determine if
+   * specific mini styles should be applied when the {@link LayoutContext.fixedAppBar}
+   * config is `false`.
+   *
+   * @internal
+   * @remarks \@since 2.8.3
+   */
+  miniHidden?: boolean;
 
   /**
    * The transition timeout to use for the toggleable `LayoutNavigation` either
@@ -69,6 +79,7 @@ export const LayoutMain = forwardRef<HTMLDivElement, LayoutMainProps>(
       timeout: propTimeout = DEFAULT_SHEET_TIMEOUT,
       classNames = DEFAULT_LAYOUT_MAIN_CLASSNAMES,
       mini = false,
+      miniHidden = false,
       ...props
     },
     forwardedRef
@@ -88,7 +99,7 @@ export const LayoutMain = forwardRef<HTMLDivElement, LayoutMainProps>(
       tabIndex = -1;
     }
 
-    const { layout, visible } = useLayoutConfig();
+    const { layout, visible, fixedAppBar } = useLayoutConfig();
     let navOffset = propNavOffset;
     if (typeof navOffset === "undefined") {
       navOffset = visible && !isTemporaryLayout(layout);
@@ -120,6 +131,14 @@ export const LayoutMain = forwardRef<HTMLDivElement, LayoutMainProps>(
       },
     });
 
+    const isMini = mini && (fixedAppBar || miniHidden);
+    const isMiniOffset =
+      mini &&
+      navOffset &&
+      !fixedAppBar &&
+      visible &&
+      isToggleableLayout(layout);
+
     return (
       <Component
         {...props}
@@ -127,8 +146,9 @@ export const LayoutMain = forwardRef<HTMLDivElement, LayoutMainProps>(
         tabIndex={tabIndex}
         className={cn(
           styles({
-            mini: mini && (isTemporaryLayout(layout) || !visible),
-            "nav-offset": mini,
+            mini: isMini && (isTemporaryLayout(layout) || !visible),
+            "nav-offset": isMini,
+            "mini-offset": isMiniOffset,
             "header-offset": headerOffset,
           }),
           className

--- a/packages/layout/src/LayoutNavigation.tsx
+++ b/packages/layout/src/LayoutNavigation.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, ReactNode } from "react";
 import cn from "classnames";
 import { Sheet, SheetProps } from "@react-md/sheet";
-import { BaseTreeItem } from "@react-md/tree";
+import { BaseTreeItem, TreeItemRenderer } from "@react-md/tree";
 import { bem, PropsWithRef } from "@react-md/utils";
 
 import { LayoutCloseNavigationButtonProps } from "./LayoutCloseNavigationButton";
@@ -17,6 +17,7 @@ import {
   isTemporaryLayout,
   isToggleableLayout,
 } from "./utils";
+import { defaultMiniNavigationItemRenderer } from "./defaultMiniNavigationItemRenderer";
 
 export type LayoutNavigationSheetProps = Omit<
   SheetProps,
@@ -94,6 +95,18 @@ export interface LayoutNavigationProps<
    * @remarks \@since 2.7.0
    */
   mini?: boolean;
+
+  /**
+   * Boolean if the mini navigation should be treated as a "sticky" element.
+   * This should really only be `true` if disabling the fixed `AppBar` behavior
+   * in the `Layout`.
+   *
+   * @remarks \@since 2.8.3
+   */
+  sticky?: boolean;
+
+  /** @remarks \@since 2.8.3 */
+  miniNavItemRenderer?: TreeItemRenderer<T>;
 }
 
 const styles = bem("rmd-layout-navigation");
@@ -120,6 +133,8 @@ export const LayoutNavigation = forwardRef<
     closeNav,
     closeNavProps,
     treeProps,
+    sticky = false,
+    miniNavItemRenderer = defaultMiniNavigationItemRenderer,
     ...props
   },
   ref
@@ -172,6 +187,7 @@ export const LayoutNavigation = forwardRef<
       className={cn(
         styles({
           mini,
+          sticky,
           floating,
           "header-offset": layout === "clipped" || floating,
         }),
@@ -179,7 +195,14 @@ export const LayoutNavigation = forwardRef<
       )}
     >
       {header}
-      {treeProps && <LayoutTree {...treeProps} mini={mini} />}
+      {treeProps && (
+        <LayoutTree
+          miniItemRenderer={miniNavItemRenderer}
+          sticky={mini && sticky}
+          {...treeProps}
+          mini={mini}
+        />
+      )}
       {children}
     </Sheet>
   );

--- a/packages/layout/src/LayoutProvider.tsx
+++ b/packages/layout/src/LayoutProvider.tsx
@@ -60,6 +60,14 @@ export interface LayoutContext {
    * A function that will set the `visible` state to `false`.
    */
   hideNav(): void;
+
+  /**
+   * Boolean if the layout is currently using a fixed app bar which can be
+   * useful for determining specific scroll or layout behavior.
+   *
+   * @remarks \@since 2.8.3
+   */
+  fixedAppBar: boolean;
 }
 
 const context = createContext<LayoutContext>({
@@ -68,6 +76,7 @@ const context = createContext<LayoutContext>({
   visible: false,
   showNav: notInitialized("showNav"),
   hideNav: notInitialized("hideNav"),
+  fixedAppBar: true,
 });
 
 /**
@@ -90,6 +99,9 @@ export interface LayoutProviderProps extends LayoutConfiguration {
    * The children to render that can inherit the current layout.
    */
   children: ReactNode;
+
+  /** {@inheritDoc LayoutContext.fixedAppBar} */
+  fixedAppBar?: boolean;
 }
 
 /**
@@ -119,6 +131,7 @@ export function LayoutProvider({
   desktopLayout = DEFAULT_DESKTOP_LAYOUT,
   largeDesktopLayout,
   defaultToggleableVisible = false,
+  fixedAppBar = true,
   children,
 }: LayoutProviderProps): ReactElement {
   const appSize = useAppSize();
@@ -165,8 +178,9 @@ export function LayoutProvider({
       visible,
       showNav,
       hideNav,
+      fixedAppBar,
     }),
-    [baseId, layout, visible, showNav, hideNav]
+    [baseId, layout, visible, showNav, hideNav, fixedAppBar]
   );
 
   return <Provider value={value}>{children}</Provider>;

--- a/packages/layout/src/LayoutTree.tsx
+++ b/packages/layout/src/LayoutTree.tsx
@@ -1,6 +1,12 @@
 import React, { CSSProperties, forwardRef, useEffect, useRef } from "react";
 import cn from "classnames";
-import { BaseTreeItem, Tree, TreeData, TreeProps } from "@react-md/tree";
+import {
+  BaseTreeItem,
+  Tree,
+  TreeData,
+  TreeItemRenderer,
+  TreeProps,
+} from "@react-md/tree";
 import { bem } from "@react-md/utils";
 
 import { defaultMiniNavigationItemRenderer } from "./defaultMiniNavigationItemRenderer";
@@ -11,9 +17,8 @@ import { isTemporaryLayout } from "./utils";
 
 const styles = bem("rmd-layout-nav");
 
-export type BaseLayoutTreeProps<
-  T extends BaseTreeItem = LayoutNavigationItem
-> = Omit<TreeProps<T>, "id" | "data" | "aria-label" | "aria-labelledby">;
+export type BaseLayoutTreeProps<T extends BaseTreeItem = LayoutNavigationItem> =
+  Omit<TreeProps<T>, "id" | "data" | "aria-label" | "aria-labelledby">;
 
 export interface LayoutTreeProps<T extends BaseTreeItem = LayoutNavigationItem>
   extends BaseLayoutTreeProps<T> {
@@ -46,6 +51,22 @@ export interface LayoutTreeProps<T extends BaseTreeItem = LayoutNavigationItem>
    * @remarks \@since 2.7.0
    */
   mini?: boolean;
+
+  /**
+   * Boolean if the mini navigation should be treated as a "sticky" element.
+   * This should really only be `true` if disabling the fixed `AppBar` behavior
+   * in the `Layout`.
+   *
+   * @remarks \@since 2.8.3
+   */
+  sticky?: boolean;
+
+  /**
+   * The {@link TreeItemRenderer} to use if the `mini` prop is enabled.
+   *
+   * @remarks \@since 2.8.3
+   */
+  miniItemRenderer?: TreeItemRenderer<T>;
 
   /**
    * Optional style to provide to the `<nav>` element surrounding the tree
@@ -84,14 +105,14 @@ export const LayoutTree = forwardRef<HTMLUListElement, LayoutTreeProps>(
       "aria-label": ariaLabel = ariaLabelledBy ? undefined : "Navigation",
       className,
       mini = false,
+      sticky = false,
       navStyle,
       navClassName,
       navItems,
       labelKey = "children",
       valueKey = "children",
-      itemRenderer = mini
-        ? defaultMiniNavigationItemRenderer
-        : defaultNavigationItemRenderer,
+      itemRenderer = defaultNavigationItemRenderer,
+      miniItemRenderer = defaultMiniNavigationItemRenderer,
       selectedIds,
       disableTemporaryAutoclose = false,
       ...props
@@ -127,7 +148,7 @@ export const LayoutTree = forwardRef<HTMLUListElement, LayoutTreeProps>(
       <nav
         id={`${id}-nav`}
         style={navStyle}
-        className={cn(styles({ mini }), navClassName)}
+        className={cn(styles({ sticky, grow: !sticky }), navClassName)}
       >
         <Tree
           {...props}
@@ -139,7 +160,7 @@ export const LayoutTree = forwardRef<HTMLUListElement, LayoutTreeProps>(
           labelKey={labelKey}
           valueKey={valueKey}
           selectedIds={selectedIds}
-          itemRenderer={itemRenderer}
+          itemRenderer={mini ? miniItemRenderer : itemRenderer}
           className={cn("rmd-layout-tree", className)}
         />
       </nav>

--- a/packages/layout/src/MiniLayoutWrapper.tsx
+++ b/packages/layout/src/MiniLayoutWrapper.tsx
@@ -1,0 +1,145 @@
+import React, { HTMLAttributes, ReactElement, ReactNode } from "react";
+import cn from "classnames";
+import { BaseTreeItem, TreeData } from "@react-md/tree";
+import { bem, PropsWithRef } from "@react-md/utils";
+
+import { LayoutNavigation, LayoutNavigationProps } from "./LayoutNavigation";
+import { LayoutNavigationItem } from "./types";
+import { useLayoutConfig } from "./LayoutProvider";
+
+const styles = bem("rmd-layout-mini-wrapper");
+
+/**
+ * This is probably an internal only interface.
+ *
+ * @remarks \@since 2.8.3
+ */
+export interface MiniLayoutWrapperProps<
+  T extends BaseTreeItem = LayoutNavigationItem
+> extends LayoutNavigationProps<T> {
+  /**
+   * Boolean if the current layout is one of the `mini` types.
+   */
+  mini: boolean;
+
+  /**
+   * A custom implementation for the main mini navigation component within the
+   * `Layout`. If this is not `undefined`, it will be used instead of the
+   * default implementation.
+   *
+   * Using this prop will make the following props do nothing for the mini nav:
+   *
+   * - `navProps`
+   * - `navHeader`
+   * - `navHeaderProps`
+   * - `navHeaderTitle`
+   * - `navHeaderTitleProps`
+   * - `closeNav`
+   * - `closeNavProps`
+   * - `treeProps`
+   *
+   * @remarks \@since.2.7.0
+   */
+  miniNav?: ReactNode;
+
+  /**
+   * An optional tree to use for the mini navigation pane since the default
+   * behavior of rendering mini tree items might hide content in an
+   * undersireable way.
+   *
+   * @remarks \@since 2.7.0
+   * @see {@link defaultMiniNavigationItemRenderer} for more information
+   */
+  miniNavItems?: TreeData<T>;
+
+  /**
+   * Boolean if the `mini` layout should be hidden. This should normally happen
+   * after the non-mini layout becomes visible.
+   */
+  miniHidden: boolean;
+
+  /**
+   * Any additional props to provide to the wrapping `<div>`.
+   */
+  containerProps?: PropsWithRef<HTMLAttributes<HTMLDivElement>, HTMLDivElement>;
+
+  /**
+   * The children to render. This should normally be the `LayoutMain` component.
+   */
+  children: ReactNode;
+}
+
+/**
+ * This is probably an internal only component.
+ *
+ * @remarks \@since 2.8.3
+ */
+export function MiniLayoutWrapper({
+  mini,
+  miniHidden,
+  miniNav,
+  miniNavItems,
+  treeProps,
+  header,
+  headerProps,
+  headerTitle,
+  headerTitleProps,
+  closeNav,
+  closeNavProps,
+  children,
+  containerProps,
+  ...props
+}: MiniLayoutWrapperProps): ReactElement {
+  const { fixedAppBar } = useLayoutConfig();
+  if (!mini || !treeProps || typeof miniNav !== "undefined") {
+    return (
+      <>
+        {miniNav}
+        {children}
+      </>
+    );
+  }
+
+  let miniTreeProps = treeProps;
+  if (miniNavItems) {
+    miniTreeProps = {
+      ...miniTreeProps,
+      navItems: miniNavItems,
+    };
+  }
+
+  const miniNavigation = (
+    <LayoutNavigation
+      header={header}
+      headerProps={headerProps}
+      headerTitle={headerTitle}
+      headerTitleProps={headerTitleProps}
+      closeNav={closeNav}
+      closeNavProps={closeNavProps}
+      treeProps={miniTreeProps}
+      {...props}
+      mini
+      sticky={!fixedAppBar}
+      hidden={miniHidden}
+    />
+  );
+
+  if (fixedAppBar) {
+    return (
+      <>
+        {miniNavigation}
+        {children}
+      </>
+    );
+  }
+
+  return (
+    <div
+      {...containerProps}
+      className={cn(!miniHidden && styles(), containerProps?.className)}
+    >
+      {miniNavigation}
+      {children}
+    </div>
+  );
+}

--- a/packages/layout/src/__tests__/__snapshots__/Layout.tsx.snap
+++ b/packages/layout/src/__tests__/__snapshots__/Layout.tsx.snap
@@ -185,7 +185,7 @@ exports[`Layout mini variant should display only valid nav items at the root in 
   tabindex="-1"
 >
   <nav
-    class="rmd-layout-nav rmd-layout-nav--mini"
+    class="rmd-layout-nav rmd-layout-nav--grow"
     id="layout-navigation-tree-nav"
   >
     <ul

--- a/packages/layout/src/__tests__/__snapshots__/Layout.tsx.snap
+++ b/packages/layout/src/__tests__/__snapshots__/Layout.tsx.snap
@@ -206,7 +206,7 @@ exports[`Layout mini variant should display only valid nav items at the root in 
         tabindex="-1"
       >
         <span
-          class="rmd-tree-item__content rmd-tree-item__content--clickable rmd-tree-item__content--selected"
+          class="rmd-tree-item__content rmd-tree-item__content--clickable rmd-tree-item__content--selected rmd-layout-nav__mini-item"
         >
           <svg
             aria-hidden="true"
@@ -239,7 +239,7 @@ exports[`Layout mini variant should display only valid nav items at the root in 
         tabindex="-1"
       >
         <span
-          class="rmd-tree-item__content rmd-tree-item__content--clickable"
+          class="rmd-tree-item__content rmd-tree-item__content--clickable rmd-layout-nav__mini-item"
         >
           <svg
             aria-hidden="true"
@@ -276,7 +276,7 @@ exports[`Layout mini variant should display only valid nav items at the root in 
         tabindex="-1"
       >
         <span
-          class="rmd-tree-item__content rmd-tree-item__content--clickable"
+          class="rmd-tree-item__content rmd-tree-item__content--clickable rmd-layout-nav__mini-item"
         >
           <svg
             aria-hidden="true"

--- a/packages/layout/src/_mixins.scss
+++ b/packages/layout/src/_mixins.scss
@@ -110,6 +110,10 @@
 
     flex: 1 1 auto;
     height: 100%;
+
+    &__mini-item {
+      justify-content: center;
+    }
   }
 
   .rmd-layout-tree {

--- a/packages/layout/src/_mixins.scss
+++ b/packages/layout/src/_mixins.scss
@@ -103,13 +103,26 @@
 
       z-index: $rmd-layout-navigation-mini-z-index;
     }
+
+    &--sticky {
+      overflow: visible;
+      position: initial;
+    }
   }
 
   .rmd-layout-nav {
     @include rmd-utils-scroll;
 
-    flex: 1 1 auto;
-    height: 100%;
+    &--grow {
+      flex: 1 1 auto;
+      height: 100%;
+    }
+
+    &--sticky {
+      position: sticky;
+      top: 0;
+      will-change: transform;
+    }
 
     &__mini-item {
       justify-content: center;
@@ -153,6 +166,11 @@
     }
   }
 
+  .rmd-layout-mini-wrapper {
+    display: grid;
+    grid-template-columns: rmd-layout-theme-var(mini-nav-width) 1fr;
+  }
+
   .rmd-layout-main {
     // going to replace the default focus outline with the custom box-shadow
     // instead
@@ -188,15 +206,10 @@
     }
 
     &--nav-offset {
-      @include rmd-utils-rtl {
-        @include rmd-layout-theme(margin-right, nav-width);
-
-        margin-left: auto;
-      }
-
-      // might need to change to just left and right instead of margin-left and
-      // margin-right for some browser support
-      @include rmd-layout-theme(margin-left, nav-width);
+      @include rmd-utils-rtl-auto(
+        margin-left,
+        rmd-layout-theme-var(main-offset)
+      );
     }
 
     &--mini {
@@ -204,6 +217,12 @@
         nav-width,
         rmd-layout-theme-var(mini-nav-width)
       );
+    }
+
+    &--mini-offset {
+      $distance: '#{rmd-layout-theme-var(nav-width)} - #{rmd-layout-theme-var(mini-nav-width)}';
+
+      @include rmd-layout-theme-update-var(main-offset, calc(#{$distance}));
     }
   }
 }

--- a/packages/layout/src/_variables.scss
+++ b/packages/layout/src/_variables.scss
@@ -64,4 +64,5 @@ $rmd-layout-mini-navigation-width: 3.5rem !default;
 $rmd-layout-theme-values: (
   nav-width: $rmd-layout-navigation-width,
   mini-nav-width: $rmd-layout-mini-navigation-width,
+  main-offset: var(--rmd-layout-nav-width, $rmd-layout-navigation-width),
 ) !default;

--- a/packages/layout/src/defaultMiniNavigationItemRenderer.tsx
+++ b/packages/layout/src/defaultMiniNavigationItemRenderer.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode } from "react";
+import cn from "classnames";
 import { Divider } from "@react-md/divider";
 import { TreeItem, TreeItemRenderer } from "@react-md/tree";
 import { SrOnly } from "@react-md/typography";
@@ -25,70 +26,74 @@ import { LayoutNavigationItem } from "./types";
  * @see {@link TreeItemRenderer}
  * @see {@link defaultNavigationItemRenderer}
  */
-export const defaultMiniNavigationItemRenderer: TreeItemRenderer<LayoutNavigationItem> = (
-  itemProps,
-  item,
-  { linkComponent, getItemProps, getItemLabel, labelKey }
-) => {
-  const { key, renderChildItems, ...props } = itemProps;
-  const {
-    divider,
-    subheader,
-    leftAddon,
-    parentId,
-    style,
-    className,
-    liStyle,
-    liClassName,
-    as,
-    to,
-    href,
-    isLink,
-    contentComponent: propContentComponent,
-  } = item;
+export const defaultMiniNavigationItemRenderer: TreeItemRenderer<LayoutNavigationItem> =
+  (
+    itemProps,
+    item,
+    { linkComponent, getItemProps, getItemLabel, labelKey }
+  ) => {
+    const { key, renderChildItems, ...props } = itemProps;
+    const {
+      divider,
+      subheader,
+      leftAddon,
+      parentId,
+      style,
+      className,
+      liStyle,
+      liClassName,
+      as,
+      to,
+      href,
+      isLink,
+      contentComponent: propContentComponent,
+    } = item;
 
-  if (divider && parentId === null) {
-    return <Divider key={key} />;
-  }
+    if (divider && parentId === null) {
+      return <Divider key={key} />;
+    }
 
-  if (subheader || parentId !== null || !leftAddon || renderChildItems) {
-    return null;
-  }
+    if (subheader || parentId !== null || !leftAddon || renderChildItems) {
+      return null;
+    }
 
-  let contentComponent = propContentComponent;
-  if (!contentComponent && isLink !== false && (to || href || isLink)) {
-    contentComponent = linkComponent;
-  }
+    let contentComponent = propContentComponent;
+    if (!contentComponent && isLink !== false && (to || href || isLink)) {
+      contentComponent = linkComponent;
+    }
 
-  const { focused, selected, expanded } = itemProps;
-  const overrides = getItemProps({
-    ...item,
-    focused,
-    selected,
-    expanded,
-  });
-  let children: ReactNode = (overrides && overrides.children) || undefined;
-  if (typeof children === "undefined") {
-    children = getItemLabel(item, labelKey);
-  }
+    const { focused, selected, expanded } = itemProps;
+    const overrides = getItemProps({
+      ...item,
+      focused,
+      selected,
+      expanded,
+    });
+    let children: ReactNode = (overrides && overrides.children) || undefined;
+    if (typeof children === "undefined") {
+      children = getItemLabel(item, labelKey);
+    }
 
-  return (
-    <TreeItem
-      key={key}
-      {...props}
-      as={as}
-      to={to}
-      href={href}
-      isLink={isLink}
-      contentComponent={contentComponent}
-      style={overrides?.style ?? style}
-      className={overrides?.className ?? className}
-      liStyle={overrides?.liStyle ?? liStyle}
-      liClassName={overrides?.liClassName ?? liClassName}
-      textChildren={false}
-    >
-      {leftAddon}
-      <SrOnly>{children}</SrOnly>
-    </TreeItem>
-  );
-};
+    return (
+      <TreeItem
+        key={key}
+        {...props}
+        as={as}
+        to={to}
+        href={href}
+        isLink={isLink}
+        contentComponent={contentComponent}
+        style={overrides?.style ?? style}
+        className={cn(
+          "rmd-layout-nav__mini-item",
+          overrides?.className ?? className
+        )}
+        liStyle={overrides?.liStyle ?? liStyle}
+        liClassName={overrides?.liClassName ?? liClassName}
+        textChildren={false}
+      >
+        {leftAddon}
+        <SrOnly>{children}</SrOnly>
+      </TreeItem>
+    );
+  };


### PR DESCRIPTION
This should fix the non-fixed AppBar mini layouts. This also adds a few new props to the layout to switch between the `itemRenderer` and `miniItemRenderer`.

> Note: The `toggleable-mini` layout doesn't animate perfectly when using a non-fixed AppBar, but it seems decent enough.

Closes #1101