### PR TITLE
Simplifiying format and covering json and yml files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,16 @@ examples/create-react-app/README.md
 examples/create-react-app-typescript/README.md
 CHANGELOG.md
 **/CHANGELOG.md
+
+coverage
+node_modules
+
+/themes/*
+packages/*/es
+packages/*/lib
+packages/*/bin
+packages/*/dist
+packages/*/types
+packages/*/.next
+packages/documentation/src/constants/sassdoc
+packages/documentation/src/constants/sandboxes

--- a/package.json
+++ b/package.json
@@ -33,10 +33,7 @@
     "lint-styles": "sass-lint -c .sass-lint.yml -v",
     "lint": "npm-run-all lint-scripts lint-styles typecheck",
     "test": "jest",
-    "format-examples": "prettier --write \"examples/*/src/**/*.{js,jsx,ts,tsx,scss}\"",
-    "format-root": "prettier --write \"*.{js,ts,md}\" \"{.github,testSetup}/*\"",
-    "format-pkgs": "prettier --write \"packages/*/{src,components,constants,hooks,pages,scripts,server,utils}/**/*.{ts,tsx,scss,js,jsx,md}\"",
-    "format": "npm-run-all format-root format-pkgs format-examples",
+    "format": "prettier --write \"**/*.{ts,tsx,scss,js,jsx,md,yml,json}\"",
     "clean": "dev-utils clean",
     "clean-dev-utils": "yarn workspace @react-md/dev-utils clean",
     "clean-all": "npm-run-all clean clean-dev-utils",
@@ -93,13 +90,7 @@
     "typescript": "^4.3.5"
   },
   "lint-staged": {
-    "**/*.{js,jsx,md}": [
-      "prettier --write"
-    ],
-    "{.github,testSetup}/*": [
-      "prettier --write"
-    ],
-    "packages/*/src/**/*.{ts,tsx,scss,js,jsx}": [
+    "**/*.{ts,tsx,scss,js,jsx,md,yml,json}": [
       "prettier --write"
     ]
   },

--- a/packages/dev-utils/src/configs.ts
+++ b/packages/dev-utils/src/configs.ts
@@ -9,7 +9,7 @@ import {
   packagesRoot,
   TSConfigType,
 } from "./constants";
-import { clean, getDependencies, getPackages, glob } from "./utils";
+import { clean, getDependencies, getPackages, glob, format } from "./utils";
 
 const NPM_IGNORE_CONTENTS = `src/**/__tests__
 src/**/*.scss
@@ -123,16 +123,30 @@ export async function configs(): Promise<void> {
       const promises: Promise<void>[] = [];
       if (!NO_STYLES_PACKAGES.test(name) && name !== "react-md") {
         const varConfig = createTSConfig("var", []);
-        promises.push(writeJson(join(path, "tsconfig.var.json"), varConfig));
+        promises.push(
+          writeFile(
+            join(path, "tsconfig.var.json"),
+            format(JSON.stringify(varConfig))
+          )
+        );
       }
 
       if (!NO_SCRIPT_PACKAGES.test(name)) {
         const ejsConfig = createTSConfig("ejs", rmdTsDependencies);
         const cjsConfig = createTSConfig("cjs", rmdTsDependencies);
         promises.push(
-          writeJson(join(path, "tsconfig.json"), TSCONFIG),
-          writeJson(join(path, "tsconfig.ejs.json"), ejsConfig),
-          writeJson(join(path, "tsconfig.cjs.json"), cjsConfig),
+          writeFile(
+            join(path, "tsconfig.json"),
+            format(JSON.stringify(TSCONFIG))
+          ),
+          writeFile(
+            join(path, "tsconfig.ejs.json"),
+            format(JSON.stringify(ejsConfig))
+          ),
+          writeFile(
+            join(path, "tsconfig.cjs.json"),
+            format(JSON.stringify(cjsConfig))
+          ),
           writeFile(join(path, ".npmignore"), NPM_IGNORE_CONTENTS)
         );
       }


### PR DESCRIPTION
Hi @mlaursen, I am working with dependencies in your project and I notes that **json** files and **ymI** were not covered by prettier, so I change a little the configuration to avoid that.

After apply the new format configuration, I notes that you autogenerate tsconfig files, so I change also dev-utils code to prettify this code too.

I did execute this new config, because it change many files and it is my first pull request in react-md, I prefer that you apply that for me ;). The process to check this change could be (from the project root):

- Apply the new format configuration:
$> yarn format

- Stage the changes to compare later:
$> git add .

- Built dev-utils:
$> yarn build-dev-utils

- Generate tsconfig files:
$> yarn dev-utils configs

- Check that there is not changes in the autogenerated files.

With the new format configuration the command "yarn format" take quite long time, but this command should not be execute frequently with editor integration and lint stage.

Please let me know if I have overlooked something.

