### PR TITLE
WIP - New Menu API

### DIFF
--- a/packages/dev-utils/src/constants.ts
+++ b/packages/dev-utils/src/constants.ts
@@ -44,7 +44,7 @@ export const DEBUG = "--debug";
 export const SILENT = "--silent";
 export const CLEAN = "--clean";
 
-export const NO_STYLES_PACKAGES = /autocomplete|material-icons|portal/;
+export const NO_STYLES_PACKAGES = /autocomplete|material-icons|portal|menu2/;
 // Note: this ignores the scssVariables file
 export const NO_SCRIPT_PACKAGES = /elevation|theme/;
 

--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -20,6 +20,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@react-md/menu2": "^4.0.0",
     "classnames": "^2.3.1",
     "codesandbox": "^2.2.3",
     "date-fns": "^2.28.0",

--- a/packages/documentation/src/components/Demos/Menu/Menu2Examples.tsx
+++ b/packages/documentation/src/components/Demos/Menu/Menu2Examples.tsx
@@ -1,0 +1,28 @@
+/* eslint-disable */
+import React, { ReactElement } from "react";
+import { Divider } from "@react-md/divider";
+import { useFileUpload } from "@react-md/form";
+import { DropdownMenu, MenuItem } from "@react-md/menu2";
+
+import { MenuItemFileInput } from "./MenuItemFileInput";
+import { MenuItemTextField } from "./MenuItemTextField";
+
+export default function Menu2Examples(): ReactElement | null {
+  const { accept, onChange, stats } = useFileUpload({ maxFiles: 1 });
+  console.log("stats:", stats);
+
+  return (
+    <DropdownMenu id="dropdown-menu-v2-api" buttonChildren="Toggle">
+      <MenuItemTextField id="search-field" />
+      <MenuItem>Item 1</MenuItem>
+      <MenuItem>Item 2</MenuItem>
+      <MenuItem>Item 3</MenuItem>
+      <Divider />
+      <MenuItem>Item 4</MenuItem>
+      <MenuItem>Item 5</MenuItem>
+      <MenuItemFileInput id="some-upload" accept={accept} onChange={onChange}>
+        New Upload
+      </MenuItemFileInput>
+    </DropdownMenu>
+  );
+}

--- a/packages/documentation/src/components/Demos/Menu/MenuItemFileInput.tsx
+++ b/packages/documentation/src/components/Demos/Menu/MenuItemFileInput.tsx
@@ -1,0 +1,42 @@
+import React, { ChangeEventHandler, ReactElement, useRef } from "react";
+import { MenuItem, MenuItemProps } from "@react-md/menu2";
+
+export interface MenuItemFileInputProps
+  extends Omit<MenuItemProps, "onChange"> {
+  id: string;
+  accept?: string;
+  multiple?: boolean;
+  onChange: ChangeEventHandler<HTMLInputElement>;
+}
+
+export function MenuItemFileInput({
+  id,
+  onChange,
+  children,
+  accept,
+  multiple = false,
+  ...props
+}: MenuItemFileInputProps): ReactElement {
+  const inputRef = useRef<HTMLInputElement>(null);
+  return (
+    <MenuItem
+      {...props}
+      onClick={(event) => {
+        event.stopPropagation();
+        inputRef.current?.click();
+      }}
+    >
+      {children}
+      <input
+        id={`${id}-input`}
+        ref={inputRef}
+        type="file"
+        accept={accept}
+        onChange={onChange}
+        className="rmd-file-input"
+        value=""
+        multiple={multiple}
+      />
+    </MenuItem>
+  );
+}

--- a/packages/documentation/src/components/Demos/Menu/MenuItemTextField.tsx
+++ b/packages/documentation/src/components/Demos/Menu/MenuItemTextField.tsx
@@ -1,0 +1,57 @@
+import React, { ReactElement, useRef } from "react";
+import { TextField, TextFieldProps } from "@react-md/form";
+import { MenuItem, MenuItemProps } from "@react-md/menu2";
+
+export interface MenuItemTextFieldProps extends TextFieldProps {
+  menuProps?: Readonly<MenuItemProps>;
+}
+
+export function MenuItemTextField({
+  id,
+  menuProps,
+  dense = true,
+  ...props
+}: MenuItemTextFieldProps): ReactElement {
+  const textFieldRef = useRef<HTMLInputElement>(null);
+  return (
+    <MenuItem
+      id={`${id}-menu-item`}
+      {...menuProps}
+      onClick={(event) => {
+        menuProps?.onClick?.(event);
+        event.stopPropagation();
+      }}
+      onFocus={(event) => {
+        menuProps?.onFocus?.(event);
+        if (event.isPropagationStopped()) {
+          return;
+        }
+
+        event.stopPropagation();
+        textFieldRef.current?.focus();
+      }}
+    >
+      <TextField
+        {...props}
+        id={id}
+        ref={textFieldRef}
+        dense={dense}
+        onKeyDown={(event) => {
+          switch (event.key) {
+            case "Tab":
+            case "Escape":
+              // do default behavior
+              break;
+            case " ":
+              event.stopPropagation();
+              break;
+            default:
+              if (event.key.length === 1 || event.currentTarget.value) {
+                event.stopPropagation();
+              }
+          }
+        }}
+      />
+    </MenuItem>
+  );
+}

--- a/packages/documentation/src/components/Demos/Menu/index.tsx
+++ b/packages/documentation/src/components/Demos/Menu/index.tsx
@@ -3,6 +3,9 @@ import { IconProvider } from "@react-md/icon";
 
 import DemoPage from "../DemoPage";
 
+import Menu2Examples from "./Menu2Examples";
+import menu2Examples from "./Menu2Examples.md";
+
 import SimpleExamples from "./SimpleExamples";
 import simpleExamples from "./SimpleExamples.md";
 
@@ -29,6 +32,11 @@ import nestedDropdownMenus from "./NestedDropdownMenus.md";
 import { CustomRenderers, customRenderers } from "./CustomRenderers";
 
 const demos = [
+  {
+    name: "Menu2 Examples",
+    description: menu2Examples,
+    children: <Menu2Examples />,
+  },
   {
     name: "Simple Examples",
     description: simpleExamples,

--- a/packages/menu2/.npmignore
+++ b/packages/menu2/.npmignore
@@ -1,0 +1,6 @@
+src/**/__tests__
+src/**/*.scss
+tsconfig.json
+tsconfig.*.json
+*tsbuildinfo
+CHANGELOG.md

--- a/packages/menu2/CHANGELOG.md
+++ b/packages/menu2/CHANGELOG.md
@@ -1,0 +1,389 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [4.0.1](https://github.com/mlaursen/react-md/compare/v4.0.0...v4.0.1) (2021-11-27)
+
+
+### Bug Fixes
+
+* **@react-md/menu:** Added fixes required for Concurrent Rendering ([05ec620](https://github.com/mlaursen/react-md/commit/05ec620a4447c904f311e5f98a3580ce56ece35f))
+
+
+### Other Internal Changes
+
+* Updated imports to use `import type` when possible ([ba96bb6](https://github.com/mlaursen/react-md/commit/ba96bb62eeddcc0879f6d584aa670850203561e6))
+
+
+
+
+
+
+# [4.0.0](https://github.com/mlaursen/react-md/compare/v3.1.1...v4.0.0) (2021-11-24)
+
+
+### Bug Fixes
+
+* **@react-md/menu:** `DropdownMenu` and `Menu` portal by default ([98a6a9f](https://github.com/mlaursen/react-md/commit/98a6a9fe4c5c8cf1baf630e5969b760af93e9ad2)), closes [#1264](https://github.com/mlaursen/react-md/issues/1264)
+* **sass:** Do not use legacy global functions ([6159e16](https://github.com/mlaursen/react-md/commit/6159e161af72a6e2d5fe43afb02ef537c3f55c11))
+
+
+### Features
+
+* Update to use new JSX Transform and latest `eslint` ([8111cd3](https://github.com/mlaursen/react-md/commit/8111cd31e45bf60c1b92509264af1b71dfba5696))
+* **@react-md/transition:** No longer use findDOMNode for transitions ([cb952da](https://github.com/mlaursen/react-md/commit/cb952da5b0cd0a67b9650e45d1e29896d66f01e1))
+
+
+### Other Internal Changes
+
+* always skip lib check ([229cef1](https://github.com/mlaursen/react-md/commit/229cef1e3d338ea362c1a2eaac06204c84ff21a6))
+* **react-md:** Remove prop-types package and usage ([2637a6f](https://github.com/mlaursen/react-md/commit/2637a6f43d681a06054e3a4518f692cf51baf997))
+
+
+### Breaking Changes
+
+* Minimum React version is now 16.14 instead of 16.8
+* **@react-md/menu:** The `DropdownMenu` and `Menu` components portal by
+default. This should really only affect snapshot tests
+* **react-md:** There will no longer be run-time prop validation with
+the `prop-types` package.
+
+
+
+
+
+
+# [3.1.0](https://github.com/mlaursen/react-md/compare/v3.0.1...v3.1.0) (2021-09-10)
+
+
+### Bug Fixes
+
+* **typescript:** updated all array types to be readonly ([8f71bcb](https://github.com/mlaursen/react-md/commit/8f71bcbde12928434975c6836079c3dda7c6ab1f))
+
+
+### Other Internal Changes
+
+* ran `yarn format` to include new files ([48d3d7f](https://github.com/mlaursen/react-md/commit/48d3d7fddb0435edf7dec9d0ba38cf3f0f251709))
+
+
+
+
+
+
+## [3.0.1](https://github.com/mlaursen/react-md/compare/v3.0.0...v3.0.1) (2021-08-15)
+
+
+### Bug Fixes
+
+* Updated peerDependencies to fix yarn berry peer requirements ([250efcd](https://github.com/mlaursen/react-md/commit/250efcdd81ea39c06b08eb30109589c89d9b8e0f)), closes [#1224](https://github.com/mlaursen/react-md/issues/1224)
+
+
+
+
+
+
+# [3.0.0](https://github.com/mlaursen/react-md/compare/v2.9.1...v3.0.0) (2021-08-13)
+
+**Note:** Version bump only for package @react-md/menu
+
+
+
+
+
+## [2.9.1](https://github.com/mlaursen/react-md/compare/v2.9.0...v2.9.1) (2021-07-27)
+
+
+### Other Internal Changes
+
+* **install:** slighly reduce install size by excluding tests in publish ([9d01a44](https://github.com/mlaursen/react-md/commit/9d01a44b81b619d6ac1c4d458005c99838fc6894))
+
+
+
+
+
+
+# [2.9.0](https://github.com/mlaursen/react-md/compare/v2.8.5...v2.9.0) (2021-07-18)
+
+**Note:** Version bump only for package @react-md/menu
+
+
+
+
+
+## [2.8.5](https://github.com/mlaursen/react-md/compare/v2.8.4...v2.8.5) (2021-07-03)
+
+**Note:** Version bump only for package @react-md/menu
+
+
+
+
+
+## [2.8.4](https://github.com/mlaursen/react-md/compare/v2.8.3...v2.8.4) (2021-06-10)
+
+
+### Other Internal Changes
+
+* ran `prettier` after upgrading to v2.3.0 ([3ce236a](https://github.com/mlaursen/react-md/commit/3ce236a6008ff3d57f16cf3f6ab8e85fcce1dd4d))
+
+
+
+
+
+
+## [2.8.3](https://github.com/mlaursen/react-md/compare/v2.8.2...v2.8.3) (2021-05-18)
+
+
+### Documentation
+
+* **react-md.dev:** updated tsdoc to work with `typedoc` ([cf54c35](https://github.com/mlaursen/react-md/commit/cf54c359268332245d1dad8a8d91e0476cd8cb33))
+
+
+
+
+
+
+## [2.8.2](https://github.com/mlaursen/react-md/compare/v2.8.1...v2.8.2) (2021-04-23)
+
+**Note:** Version bump only for package @react-md/menu
+
+
+
+
+
+# [2.8.0](https://github.com/mlaursen/react-md/compare/v2.7.1...v2.8.0) (2021-04-22)
+
+
+### Other Internal Changes
+
+* **tsconfig:** separate tsconfig by package instead of a single root ([b278230](https://github.com/mlaursen/react-md/commit/b2782303b2a2db07eeaa25b6a3d04337976cffaa))
+
+
+
+
+
+
+## [2.7.1](https://github.com/mlaursen/react-md/compare/v2.7.0...v2.7.1) (2021-03-23)
+
+
+### Other Internal Changes
+
+* **ts:** stopped using FC type ([c5daa47](https://github.com/mlaursen/react-md/commit/c5daa47d73516e075c036fd745e7228d7f155a62))
+
+
+
+
+
+
+# [2.7.0](https://github.com/mlaursen/react-md/compare/v2.6.0...v2.7.0) (2021-02-28)
+
+
+### Bug Fixes
+
+* **@react-md/menu:** fixed menu color when dark theme elevation is enabled ([52c752d](https://github.com/mlaursen/react-md/commit/52c752d05a4a3cb3fb0119e213db7b58218fbfa9)), closes [#1075](https://github.com/mlaursen/react-md/issues/1075)
+
+
+### Documentation
+
+* **tsdoc:** fixed remaining tsdoc syntax warnings ([946f4dd](https://github.com/mlaursen/react-md/commit/946f4dddf380b9f2313fb76d54d969aa2adbff53))
+* **tsdoc:** fixed some tsdoc annotations and styling ([0449b86](https://github.com/mlaursen/react-md/commit/0449b86e4e51793710b35a452b7ebcbb6e7b5b2e))
+
+
+### Other Internal Changes
+
+* updated test coverage to not include conditional component PropTypes ([24e5df1](https://github.com/mlaursen/react-md/commit/24e5df14c731411d7691253383435036326407b5))
+
+
+
+
+
+
+# [2.6.0](https://github.com/mlaursen/react-md/compare/v2.5.5...v2.6.0) (2021-02-13)
+
+**Note:** Version bump only for package @react-md/menu
+
+
+
+
+
+## [2.5.5](https://github.com/mlaursen/react-md/compare/v2.5.4...v2.5.5) (2021-01-30)
+
+**Note:** Version bump only for package [@react-md/menu](../menu)
+
+## [2.5.4](https://github.com/mlaursen/react-md/compare/v2.5.3...v2.5.4) (2021-01-27)
+
+**Note:** Version bump only for package [@react-md/menu](../menu)
+
+## [2.5.1](https://github.com/mlaursen/react-md/compare/v2.5.0...v2.5.1) (2020-12-16)
+
+**Note:** Version bump only for package [@react-md/menu](../menu)
+
+# [2.5.0](https://github.com/mlaursen/react-md/compare/v2.4.3...v2.5.0) (2020-12-15)
+
+**Note:** Version bump only for package [@react-md/menu](../menu)
+
+## [2.4.3](https://github.com/mlaursen/react-md/compare/v2.4.2...v2.4.3) (2020-11-14)
+
+**Note:** Version bump only for package [@react-md/menu](../menu)
+
+## [2.4.2](https://github.com/mlaursen/react-md/compare/v2.4.1...v2.4.2) (2020-10-23)
+
+### Bug Fixes
+
+- [@react-md/menu](../menu): fixed DropdownMenu not being able to provide style
+  and className to Menu
+  ([7823fea](https://github.com/mlaursen/react-md/commit/7823fea2ff2979792942534b0bc6cf753bd5ac9a)),
+  closes [#989](https://github.com/mlaursen/react-md/issues/989)
+
+## [2.4.1](https://github.com/mlaursen/react-md/compare/v2.4.0...v2.4.1) (2020-10-17)
+
+**Note:** Version bump only for package [@react-md/menu](../menu)
+
+# [2.4.0](https://github.com/mlaursen/react-md/compare/v2.3.1...v2.4.0) (2020-10-17)
+
+### Features
+
+- **a11y:** improved `LabelRequiredForA11y` type definition
+  ([b7aa4fa](https://github.com/mlaursen/react-md/commit/b7aa4fadb7b4f1a23fba4008e42d2f4a4bd47c07))
+- [@react-md/theme](../theme): Better Contrast Colors by Default and dev-utils
+  refactor ([#955](https://github.com/mlaursen/react-md/issues/955))
+  ([519b128](https://github.com/mlaursen/react-md/commit/519b128522de944d55ff96a1e1125447665ed586))
+
+## [2.3.1](https://github.com/mlaursen/react-md/compare/v2.3.0...v2.3.1) (2020-09-15)
+
+**Note:** Version bump only for package [@react-md/menu](../menu)
+
+# [2.3.0](https://github.com/mlaursen/react-md/compare/v2.2.0...v2.3.0) (2020-09-10)
+
+### Features
+
+- **a11y:** improved `LabelRequiredForA11y` type definition
+  ([b7aa4fa](https://github.com/mlaursen/react-md/commit/b7aa4fadb7b4f1a23fba4008e42d2f4a4bd47c07))
+
+## [2.2.2](https://github.com/mlaursen/react-md/compare/v2.2.1...v2.2.2) (2020-09-02)
+
+**Note:** Version bump only for package [@react-md/menu](../menu)
+
+## [2.2.1](https://github.com/mlaursen/react-md/compare/v2.2.0...v2.2.1) (2020-09-02)
+
+**Note:** Version bump only for package [@react-md/menu](../menu)
+
+# [2.2.0](https://github.com/mlaursen/react-md/compare/v2.1.2...v2.2.0) (2020-08-11)
+
+**Note:** Version bump only for package [@react-md/menu](../menu)
+
+## [2.1.2](https://github.com/mlaursen/react-md/compare/v2.1.1...v2.1.2) (2020-08-01)
+
+**Note:** Version bump only for package [@react-md/menu](../menu)
+
+## [2.1.1](https://github.com/mlaursen/react-md/compare/v2.1.0...v2.1.1) (2020-07-21)
+
+**Note:** Version bump only for package [@react-md/menu](../menu)
+
+# [2.1.0](https://github.com/mlaursen/react-md/compare/v2.0.4...v2.1.0) (2020-07-12)
+
+### Features
+
+- Improved Dark Mode using Raising Elevation
+  ([547877c](https://github.com/mlaursen/react-md/commit/547877c51217a544fdaad9c77e2469a45f30336e)),
+  closes [#860](https://github.com/mlaursen/react-md/issues/860)
+
+## [2.0.2](https://github.com/mlaursen/react-md/compare/v2.0.1...v2.0.2) (2020-06-30)
+
+### Bug Fixes
+
+- **LICENSE:** Removed the time range from license since it was incorrect
+  ([50c9021](https://github.com/mlaursen/react-md/commit/50c9021cedc0d642758b9fd541bb6c93d2fe1786))
+- Added `sideEffects` field to `package.json`
+  ([31820b9](https://github.com/mlaursen/react-md/commit/31820b9b43705e5849664500a17b6849eb6dc2a9))
+- `sideEffects` formatting
+  ([78a7b6b](https://github.com/mlaursen/react-md/commit/78a7b6b0e40c7daefb749835670705f21bd21720))
+
+## v2.0.1
+
+No changes.
+
+## v2.0.0
+
+The menu package was completely re-written to fix all the accessibility issues
+and keyboard focus behavior.
+
+The main exports starting in v2:
+
+- `DropdownMenu`
+- `MenuItem`
+- `MenuItemLink`
+- `MenuItemSeparator`
+- `DropdownMenuItem`
+- `defaultMenuRenderer`
+- `defaultMenuItemRenderer`
+- `useContextMenu`
+
+### New Features / Behavior
+
+- the menu will now automatically position itself within the viewport with fixed
+  positioning
+- implemented custom context menus with a new `useContextMenu` hook
+- nested dropdown menus are fully supported along with keyboard movement and
+  open/close behavior
+- no longer use the `menuItem` props and instead render the `MenuItem` component
+  instead within the `DropdownMenu`
+- no longer uses the weird `Layover` component
+
+### Breaking Changes
+
+- the visibility for the menus can no longer be controlled externally. this
+  functionality will come back in a later release
+- the menu no longer supports relative positioning
+- the `MenuButton` is no longer a combination of a `Button` and a `Menu` and
+  instead is an accessibility helper component
+
+#### New SCSS Variables, Functions, and Mixins
+
+- `$rmd-menu-background-color: rmd-theme-var(surface) !default` - The background
+  color to use in menus
+- `$rmd-menu-color: rmd-theme-var(on-surface) !default` - The text color to use
+  in menus
+- `$rmd-menu-elevation: 8 !default` - The elevation/box shadow to use for the
+  menu
+- `@function rmd-menu-theme` - gets one of the theme values and validates that
+  the theme name is valid
+- `@function rmd-menu-theme-var` - gets one of the theme values as a css
+  variable with a fallback value and validates that the theme name is valid
+- `@mixin rmd-menu-theme` - applies one of the theme values to a css property as
+  a css variable
+- `@mixin rmd-menu-theme-update-var` - updates one of the theme values as a css
+  variable
+
+#### Renamed SCSS Variables, Functions, and Mixins
+
+- renamed `$md-menu-z-index` to `$rmd-menu-z-index` and changed the default
+  value from `null` (`100` from `Layover`) to `11`
+- renamed `$md-menu-min-width` to `$rmd-menu-min-width` and changed the default
+  value from `112px` to `7rem`
+
+#### Removed SCSS Variables and Mixins
+
+- removed `$md-menu-include-cascading`, `$md-menu-include-cascading-styles`,
+  `$md-menu-cascading-font-size`, `$md-menu-cascading-padding`,
+  `$md-cascading-height` and `$md-menu-cascading-list-padding` since the
+  cascading/nested menus was completely reworked and no longer needs additional
+  styles
+- removed all other SCSS variables relating to height and width
+
+#### Accessibility Fixes
+
+The accessibility props were moved from the surrounding `<div>` and instead
+applied correctly to the `MenuButton` instead. This also changed the
+`aria-haspopup` attribute to be `"menu"` instead of `"true"` and removed the
+`aria-controls` since it doesn't really work as expected.
+
+Additional keyboard behavior was also added to both the `MenuButton` and `Menu`
+components. When the `MenuButton` is focused, the `ArrowUp` key will open the
+menu and focus the last `MenuItem` while the `ArrowDown` key will open the menu
+and focus the first `MenuItem`. The user can now also type while the menu is
+open to focus specific items that start with the same letters.
+
+The `Menu` now also requires the `aria-label` or `aria-labelledby` props to help
+screen readers out as well as applying `role="menu"` and
+`aria-orentation="vertical"` (or `"horizontal"`).

--- a/packages/menu2/LICENSE
+++ b/packages/menu2/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Mikkel Laursen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/packages/menu2/README.md
+++ b/packages/menu2/README.md
@@ -1,0 +1,69 @@
+# @react-md/menu
+
+Create accessible dropdown menus that auto-position themselves to stay within
+the viewport. The menus are entirely navigable with a keyboard along with some
+additional behavior:
+
+- `ArrowUp` and `ArrowDown` to focus the previous/next `MenuItem` that also
+  allows wrapping
+- `Home` and `End` to focus the first/last `Menuitem` in the menu
+- type the starting letters of a `MenuItem` to focus it
+
+<!-- DOCS_REMOVE -->
+
+> More information on the built-in accessibility can be found in the
+> [accessibility example](https://react-md.dev/packages/menu/demos#accessibility-example-title)
+> on the documentation site.
+
+<!-- DOCS_REMOVE_END -->
+
+## Installation
+
+```sh
+npm install --save @react-md/menu
+```
+
+You will also need to install the following packages for their styles:
+
+```sh
+npm install --save @react-md/theme \
+  @react-md/typography \
+  @react-md/icon \
+  @react-md/list \
+  @react-md/button \
+  @react-md/states \
+  @react-md/utils
+```
+
+<!-- DOCS_REMOVE -->
+
+## Documentation
+
+You should check out the
+[full documentation](https://react-md.dev/packages/menu/demos) for live examples
+and more customization information, but an example usage is shown below.
+
+<!-- DOCS_REMOVE_END -->
+
+## Usage
+
+```tsx
+import React from "react";
+import { render } from "react-dom";
+import { DropdownMenu } from "@react-md/menu";
+
+const App = () => (
+  <DropdownMenu
+    id="example-dropdown-menu"
+    items={[
+      { onClick: () => console.log("Clicked Item 1"), children: "Item 1" },
+      { onClick: () => console.log("Clicked Item 2"), children: "Item 2" },
+      { onClick: () => console.log("Clicked Item 3"), children: "Item 3" },
+    ]}
+  >
+    Dropdown
+  </DropdownMenu>
+);
+
+render(<App />, document.getElementById("root"));
+```

--- a/packages/menu2/package.json
+++ b/packages/menu2/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@react-md/menu2",
+  "version": "4.0.0",
+  "description": "Create menus that auto-position themselves within the viewport and adhere to the accessibility guidelines",
+  "main": "./lib/index.js",
+  "module": "./es/index.js",
+  "types": "./types/index.d.ts",
+  "sideEffects": [
+    "dist/**/*"
+  ],
+  "author": "Mikkel Laursen <mlaursen03@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mlaursen/react-md.git",
+    "directory": "packages/menu"
+  },
+  "bugs": {
+    "url": "https://github.com/mlaursen/react-md/issues"
+  },
+  "homepage": "https://react-md.dev/packages/menu/demos",
+  "keywords": [
+    "accessibility",
+    "a11y",
+    "react-md",
+    "material design",
+    "react",
+    "menu",
+    "dropdown",
+    "component",
+    "components"
+  ],
+  "license": "MIT",
+  "dependencies": {
+    "@react-md/app-bar": "^4.0.0",
+    "@react-md/button": "^4.0.0",
+    "@react-md/divider": "^4.0.0",
+    "@react-md/elevation": "^4.0.0",
+    "@react-md/icon": "^4.0.0",
+    "@react-md/list": "^4.0.0",
+    "@react-md/states": "^4.0.0",
+    "@react-md/theme": "^4.0.0",
+    "@react-md/transition": "^4.0.0",
+    "@react-md/typography": "^4.0.0",
+    "@react-md/utils": "^4.0.0",
+    "classnames": "^2.3.1"
+  },
+  "devDependencies": {
+    "react": "^17.0.2",
+    "react-dom": "^17.0.1"
+  },
+  "peerDependencies": {
+    "react": ">= 16.8",
+    "react-dom": ">= 16.8.0"
+  },
+  "optionalDependencies": {
+    "prop-types": ">= 15.6"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/menu2/src/DropdownMenu.tsx
+++ b/packages/menu2/src/DropdownMenu.tsx
@@ -1,0 +1,144 @@
+import {
+  HTMLAttributes,
+  KeyboardEventHandler,
+  ReactElement,
+  ReactNode,
+} from "react";
+import { Button, ButtonProps, ButtonThemeProps } from "@react-md/button";
+import {
+  IconRotator,
+  TextIconSpacing,
+  TextIconSpacingProps,
+  useIcon,
+} from "@react-md/icon";
+
+import { Menu } from "./Menu";
+import { useMenuVisibility } from "./useMenuVisibility";
+
+/**
+ * @remarks \@since 4.0.0
+ */
+export type DropdownMenuButtonThemeProps = Pick<
+  ButtonThemeProps,
+  "theme" | "themeType" | "buttonType"
+>;
+
+/**
+ * @remarks \@since 4.0.0
+ */
+export interface DropdownMenuProps
+  extends HTMLAttributes<HTMLDivElement>,
+    DropdownMenuButtonThemeProps,
+    Pick<TextIconSpacingProps, "icon" | "iconAfter"> {
+  /** {@inheritDoc MenuVisibilityHookOptions.toggleId} */
+  id: string;
+  /** {@inheritDoc MenuVisibilityHookOptions.menuLabel} */
+  menuLabel?: string;
+  /** {@inheritDoc MenuVisibilityHookOptions.onMenuKeyDown} */
+  onKeyDown?: KeyboardEventHandler<HTMLDivElement>;
+  /** {@inheritDoc MenuVisibilityHookOptions.horizontal} */
+  horizontal?: boolean;
+
+  /**
+   * The children to display in the button. This should normally be text or an
+   * icon.
+   *
+   * Note: If this is an icon, set the {@link buttonType} to `"icon"` to get the
+   * correct styling and remove the dropdown icon.
+   */
+  buttonChildren: ReactNode;
+
+  /**
+   * Any additional props to pass to the button component.
+   */
+  buttonProps?: Readonly<
+    Omit<ButtonProps, "children" | keyof DropdownMenuButtonThemeProps>
+  >;
+
+  /**
+   * Any additional props to pass to the {@link TextIconSpacing} component that
+   * surrounds the {@link buttonChildren}
+   */
+  textIconSpacingProps?: Readonly<
+    Omit<TextIconSpacingProps, "icon" | "iconAfter" | "children">
+  >;
+
+  /**
+   * Boolean if the dropdown icon should be included with the button children.
+   *
+   * @defaultValue `buttonType === "icon"`
+   */
+  disableDropdownIcon?: boolean;
+}
+
+/**
+ * @remarks \@since 4.0.0
+ */
+export function DropdownMenu({
+  id,
+  icon: propIcon,
+  iconAfter = true,
+  textIconSpacingProps,
+  theme = "clear",
+  themeType = "flat",
+  buttonType = "text",
+  buttonProps,
+  buttonChildren,
+  horizontal = false,
+  children,
+  menuLabel,
+  onKeyDown,
+  disableDropdownIcon = buttonType === "icon",
+  ...props
+}: DropdownMenuProps): ReactElement {
+  const { visible, defaultFocus, menuRef, menuProps, toggleRef, toggleProps } =
+    useMenuVisibility({
+      toggleId: id,
+      menuLabel,
+      horizontal,
+      onToggleClick: buttonProps?.onClick,
+      onToggleKeyDown: buttonProps?.onKeyDown,
+      onMenuKeyDown: onKeyDown,
+    });
+  const dropdownIcon = useIcon(
+    "dropdown",
+    buttonType === "icon" ? null : propIcon
+  );
+
+  let icon = dropdownIcon;
+  if (buttonType !== "icon" && !disableDropdownIcon) {
+    icon = <IconRotator rotated={visible}>{dropdownIcon}</IconRotator>;
+  }
+
+  return (
+    <>
+      <Button
+        {...toggleProps}
+        {...buttonProps}
+        ref={toggleRef}
+        theme={theme}
+        themeType={themeType}
+        buttonType={buttonType}
+      >
+        <TextIconSpacing
+          icon={icon}
+          iconAfter={iconAfter}
+          {...textIconSpacingProps}
+        >
+          {buttonChildren}
+        </TextIconSpacing>
+      </Button>
+      <Menu
+        {...props}
+        {...menuProps}
+        menuRef={menuRef}
+        toggleRef={toggleRef}
+        defaultFocus={defaultFocus}
+        visible={visible}
+        horizontal={horizontal}
+      >
+        {children}
+      </Menu>
+    </>
+  );
+}

--- a/packages/menu2/src/KeyboardFocusProvider.tsx
+++ b/packages/menu2/src/KeyboardFocusProvider.tsx
@@ -1,0 +1,135 @@
+import {
+  createContext,
+  ReactElement,
+  ReactNode,
+  Ref,
+  RefCallback,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+} from "react";
+import { applyRef, extractTextContent } from "@react-md/utils";
+
+/**
+ * @remarks \@since 4.0.0
+ * @internal
+ */
+export interface KeyboardFocusElementData {
+  element: HTMLElement;
+  content: string;
+}
+
+/**
+ * @remarks \@since 4.0.0
+ * @internal
+ */
+export interface KeyboardFocusElementLookup {
+  current: KeyboardFocusElementData[];
+}
+
+/**
+ * @remarks \@since 4.0.0
+ * @internal
+ */
+export interface KeyboardFocusContext {
+  attach<E extends HTMLElement>(element: E): void;
+  detach<E extends HTMLElement>(element: E): void;
+  watching: KeyboardFocusElementLookup;
+}
+
+/**
+ * @remarks \@since 4.0.0
+ * @internal
+ */
+const noop = (): void => {
+  if (process.env.NODE_ENV !== "production") {
+    throw new Error("KeyboardFocusProvider must be a parent component.");
+  }
+};
+
+/**
+ * @remarks \@since 4.0.0
+ * @internal
+ */
+const context = createContext<KeyboardFocusContext>({
+  attach: noop,
+  detach: noop,
+  watching: { current: [] },
+});
+context.displayName = "KeyboardFocus";
+
+/**
+ * @remarks \@since 4.0.0
+ * @internal
+ */
+const { Provider } = context;
+
+/**
+ * @remarks \@since 4.0.0
+ */
+export function useKeyboardFocusableElement<E extends HTMLElement>(
+  ref?: Ref<E>
+): RefCallback<E> {
+  const { attach, detach } = useContext(context);
+  const nodeRef = useRef<E | null>(null);
+
+  return useCallback(
+    (instance: E | null) => {
+      applyRef(instance, ref);
+      if (instance) {
+        attach(instance);
+      } else if (nodeRef.current) {
+        detach(nodeRef.current);
+      }
+
+      nodeRef.current = instance;
+    },
+    [attach, detach, ref]
+  );
+}
+
+/**
+ * @remarks \@since 4.0.0
+ * @internal
+ */
+export function useKeyboardFocusableElements(): KeyboardFocusElementLookup {
+  return useContext(context).watching;
+}
+
+/**
+ * @remarks \@since 4.0.0
+ * @internal
+ */
+export interface KeyboardFocusProviderProps {
+  children: ReactNode;
+}
+
+/**
+ * @remarks \@since 4.0.0
+ * @internal
+ */
+export function KeyboardFocusProvider({
+  children,
+}: KeyboardFocusProviderProps): ReactElement {
+  const watching = useRef<KeyboardFocusElementData[]>([]);
+  const value = useMemo<KeyboardFocusContext>(
+    () => ({
+      attach(element) {
+        watching.current.push({
+          element,
+          content: extractTextContent(element),
+        });
+      },
+      detach(element) {
+        watching.current = watching.current.filter(
+          (cache) => cache.element !== element
+        );
+      },
+      watching,
+    }),
+    []
+  );
+
+  return <Provider value={value}>{children}</Provider>;
+}

--- a/packages/menu2/src/Menu.tsx
+++ b/packages/menu2/src/Menu.tsx
@@ -1,0 +1,96 @@
+import type { ReactElement, RefObject } from "react";
+import {
+  ConditionalPortal,
+  RenderConditionalPortalProps,
+} from "@react-md/portal";
+import {
+  TransitionCallbacks,
+  useFixedPositioning,
+  useScaleTransition,
+} from "@react-md/transition";
+import { TOP_INNER_RIGHT_ANCHOR } from "@react-md/utils";
+
+import { KeyboardFocusProvider } from "./KeyboardFocusProvider";
+import { MenuWidgetProps, MenuWidget } from "./MenuWidget";
+
+/**
+ * @remarks \@since 4.0.0
+ */
+export interface MenuProps
+  extends MenuWidgetProps,
+    RenderConditionalPortalProps,
+    TransitionCallbacks {
+  menuRef: RefObject<HTMLElement>;
+  toggleRef: RefObject<HTMLElement>;
+  visible: boolean;
+
+  /**
+   * Boolean if the `toggleRef` should not be focused once the menu is closed if
+   * a MenuItem's action was to focus another element on the page. This should
+   * generally be kept at `false` for keyboard accessibility.
+   *
+   * @defaultValue `false`
+   */
+  disableToggleFocus?: boolean;
+}
+
+export function Menu({
+  portal = true,
+  portalInto,
+  portalIntoId,
+  style: propStyle,
+  className,
+  menuRef,
+  toggleRef,
+  visible,
+  onEnter,
+  onEntering,
+  onEntered,
+  onExit,
+  onExiting,
+  onExited,
+  horizontal,
+  disableToggleFocus = false,
+  ...props
+}: MenuProps): ReactElement {
+  const { style, transitionOptions } = useFixedPositioning({
+    style: propStyle,
+    nodeRef: menuRef,
+    fixedTo: toggleRef,
+    anchor: TOP_INNER_RIGHT_ANCHOR,
+    onEnter,
+    onEntered,
+    onEntering(appearing) {
+      onEntering?.(appearing);
+      menuRef.current?.focus();
+    },
+    onExited,
+    transformOrigin: true,
+  });
+  const { elementProps, rendered } = useScaleTransition({
+    ...transitionOptions,
+    className,
+    transitionIn: visible,
+    vertical: !horizontal,
+    onExit,
+    onExiting() {
+      onExiting?.();
+      if (!disableToggleFocus) {
+        toggleRef.current?.focus();
+      }
+    },
+  });
+  return (
+    <ConditionalPortal
+      portal={portal}
+      portalInto={portalInto}
+      portalIntoId={portalIntoId}
+    >
+      {rendered && (
+        <KeyboardFocusProvider>
+          <MenuWidget {...props} {...elementProps} style={style} />
+        </KeyboardFocusProvider>
+      )}
+    </ConditionalPortal>
+  );
+}

--- a/packages/menu2/src/MenuItem.tsx
+++ b/packages/menu2/src/MenuItem.tsx
@@ -1,0 +1,50 @@
+import { forwardRef } from "react";
+import cn from "classnames";
+import { ListItem, ListItemProps } from "@react-md/list";
+
+import { useKeyboardFocusableElement } from "./KeyboardFocusProvider";
+
+/**
+ * @remarks \@since 4.0.0
+ */
+export interface MenuItemProps extends ListItemProps {
+  /**
+   * An optional id for the menu item. This is generally recommended, but it can
+   * be ignored.
+   */
+  id?: string;
+
+  /**
+   * The current role for the menu item. This will eventually be updated for
+   * some of the other `menuitem*` widgets.
+   */
+  role?: "menuitem" | "button";
+
+  /**
+   * The tab index for the menu item. This should always stay at `-1`.
+   */
+  tabIndex?: number;
+}
+
+/**
+ * @remarks \@since 4.0.0
+ */
+export const MenuItem = forwardRef<HTMLLIElement, MenuItemProps>(
+  function MenuItem(
+    { className, children, role = "menuitem", tabIndex = -1, ...props },
+    nodeRef
+  ) {
+    const ref = useKeyboardFocusableElement(nodeRef);
+    return (
+      <ListItem
+        {...props}
+        ref={ref}
+        role={role}
+        tabIndex={tabIndex}
+        className={cn("rmd-menu-item", className)}
+      >
+        {children}
+      </ListItem>
+    );
+  }
+);

--- a/packages/menu2/src/MenuWidget.tsx
+++ b/packages/menu2/src/MenuWidget.tsx
@@ -1,0 +1,133 @@
+import { forwardRef, HTMLAttributes, ReactElement, useRef } from "react";
+import cn from "classnames";
+import { bem, findMatchIndex, loop } from "@react-md/utils";
+
+import { useKeyboardFocusableElements } from "./KeyboardFocusProvider";
+import type { MenuDefaultFocus } from "./types";
+
+const styles = bem("rmd-menu");
+
+/**
+ * @remarks \@since 4.0.0
+ */
+export interface MenuWidgetProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * Boolean if the menu should render horizontally instead of vertically.
+   *
+   * @defaultValue `false`
+   */
+  horizontal?: boolean;
+  defaultFocus: MenuDefaultFocus;
+}
+
+/**
+ * @remarks \@since 4.0.0
+ */
+export const MenuWidget = forwardRef<HTMLDivElement, MenuWidgetProps>(
+  function MenuWidget(
+    {
+      className,
+      children,
+      onFocus,
+      onKeyDown,
+      horizontal = false,
+      defaultFocus,
+      ...props
+    },
+    ref
+  ): ReactElement {
+    const elementsLookup = useKeyboardFocusableElements();
+    const focusIndex = useRef(-1);
+
+    return (
+      <div
+        {...props}
+        ref={ref}
+        role="menu"
+        tabIndex={-1}
+        className={cn(styles({ horizontal }), className)}
+        onFocus={(event) => {
+          onFocus?.(event);
+          if (event.isPropagationStopped() || focusIndex.current !== -1) {
+            return;
+          }
+
+          switch (defaultFocus) {
+            case "self":
+              focusIndex.current = -1;
+              break;
+            case "first":
+              focusIndex.current = 1 - 1;
+              break;
+            case "last":
+              focusIndex.current = elementsLookup.current.length - 1;
+              break;
+          }
+
+          elementsLookup.current[focusIndex.current]?.element.focus();
+        }}
+        onKeyDown={(event) => {
+          onKeyDown?.(event);
+          if (event.isPropagationStopped()) {
+            return;
+          }
+
+          if (
+            event.key.length === 1 &&
+            !event.ctrlKey &&
+            !event.altKey &&
+            !event.metaKey &&
+            !event.shiftKey
+          ) {
+            event.preventDefault();
+            event.stopPropagation();
+            const index = findMatchIndex(
+              event.key,
+              elementsLookup.current.map(({ content }) => content),
+              focusIndex.current
+            );
+            focusIndex.current = index;
+            elementsLookup.current[index]?.element.focus();
+            return;
+          }
+
+          if (!["ArrowUp", "ArrowDown", "Home", "End"].includes(event.key)) {
+            return;
+          }
+
+          event.preventDefault();
+          event.stopPropagation();
+          const lastIndex = elementsLookup.current.length - 1;
+          switch (event.key) {
+            case "ArrowUp":
+              focusIndex.current = loop({
+                value: focusIndex.current,
+                min: 1 - 1,
+                max: lastIndex,
+                increment: false,
+              });
+              break;
+            case "ArrowDown":
+              focusIndex.current = loop({
+                value: focusIndex.current,
+                min: 1 - 1,
+                max: lastIndex,
+                increment: true,
+              });
+              break;
+            case "Home":
+              focusIndex.current = 1 - 1;
+              break;
+            case "End":
+              focusIndex.current = lastIndex;
+              break;
+          }
+
+          elementsLookup.current[focusIndex.current]?.element.focus();
+        }}
+      >
+        {children}
+      </div>
+    );
+  }
+);

--- a/packages/menu2/src/index.ts
+++ b/packages/menu2/src/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @module @react-md/menu
+ */
+export * from "./DropdownMenu";
+export * from "./KeyboardFocusProvider";
+export * from "./Menu";
+export * from "./MenuItem";
+export * from "./MenuWidget";
+export * from "./types";
+export * from "./useMenuVisibility";

--- a/packages/menu2/src/types.ts
+++ b/packages/menu2/src/types.ts
@@ -1,0 +1,200 @@
+import type { KeyboardEventHandler, MouseEventHandler } from "react";
+
+/**
+ * Whenever the menu becomes visible the menu gains focus for keyboard
+ * functionality. Once the menu gains focus, the first item should normally be
+ * focused by default unless the menu was opened by pressing the `"ArrowUp"`
+ * key.
+ *
+ * Here are the valid focus types and the behavior:
+ *
+ * - `"self"` - The menu itself retains focus.
+ * - `"first"` - The first focusable element within the menu gains focus
+ * - `"last"` - The last focusable element within the menu gains focus.
+ *
+ * A "focusable" element will normally be one of the `MenuItem` components but
+ * can also be a custom component that has registered itself as a focusable
+ * element with the {@link useMenuFocusElement} hook.
+ *
+ * @defaultValue `"first"`
+ * @see {@link https://www.w3.org/TR/wai-aria-practices/#menubutton}
+ * @remarks \@since 4.0.0
+ */
+export type MenuDefaultFocus = "self" | "first" | "last";
+
+/** @remarks \@since 4.0.0 */
+export interface MenuVisibilityState {
+  /**
+   * Boolean if the menu is currently visible
+   *
+   * @defaultValue `false`
+   */
+  visible: boolean;
+
+  /** {@inheritdoc MenuDefaultFocus} */
+  defaultFocus: MenuDefaultFocus;
+}
+
+/**
+ *
+ * @see {@link https://www.w3.org/TR/wai-aria-practices/#menubutton}
+ * @typeParam ToggleElement - The `HTMLElement` type for the toggle component.
+ * Defaults to `HTMLButtonElement`.
+ * @typeParam MenuElement - The `HTMLElement` type for the menu component.
+ * Defaults to `HTMLDivElement`
+ * @remarks \@since 4.0.0
+ */
+export interface MenuVisibilityHookOptions<
+  ToggleElement extends HTMLElement = HTMLButtonElement,
+  MenuElement extends HTMLElement = HTMLDivElement
+> {
+  /**
+   * This id will be set to the {@link MenuToggleRequiredProps.id} and used to
+   * create the {@link MenuWidgetRequiredProps.id}.
+   */
+  toggleId: string;
+
+  /**
+   * An optional `aria-label` to provide to the menu element.
+   *
+   * @see {@link MenuWidgetRequiredProps.["aria-labelledby"]}
+   * @see {@link MenuWidgetRequiredProps.["aria-label"]}
+   */
+  menuLabel?: string;
+
+  /**
+   * Boolean if the menu should display horizontally instead of vertically.
+   *
+   * @defaultValue `false`
+   */
+  horizontal?: boolean;
+
+  /**
+   * An optional `onClick` event handler that will be merged with the
+   * {@link MenuWidgetRequiredProps.onClick} event handler.
+   *
+   * If this function calls `event.stopPropagation()`, the default keydown
+   * behavior will not occur.
+   */
+  onMenuClick?: MouseEventHandler<MenuElement>;
+
+  /**
+   * An optional `onKeyDown` event handler that will be merged with the
+   * {@link MenuWidgetRequiredProps.onKeyDown} event handler.
+   *
+   * If this function calls `event.stopPropagation()`, the default keydown
+   * behavior will not occur.
+   */
+  onMenuKeyDown?: KeyboardEventHandler<MenuElement>;
+
+  /**
+   * An optional `onClick` event handler that will be merged with the
+   * {@link MenuToggleRequiredProps.onClick} event handler.
+   *
+   * If this function calls `event.stopPropagation()`, the default click
+   * behavior will not occur.
+   */
+  onToggleClick?: MouseEventHandler<ToggleElement>;
+
+  /**
+   * An optional `onKeyDown` event handler that will be merged with the
+   * {@link MenuToggleRequiredProps.onKeyDown} event handler.
+   *
+   * If this function calls `event.stopPropagation()`, the default keydown
+   * behavior will not occur.
+   */
+  onToggleKeyDown?: KeyboardEventHandler<ToggleElement>;
+}
+
+/**
+ *
+ * @see {@link https://www.w3.org/TR/wai-aria-practices/#menubutton}
+ * @typeParam E - The `HTMLElement` type for the menu component. Defaults to
+ * `HTMLDivElement`.
+ * @remarks \@since 4.0.0
+ */
+export interface MenuWidgetRequiredProps<
+  E extends HTMLElement = HTMLDivElement
+> {
+  /**
+   * An optional `id` for an element that provides a label for the menu. This
+   * will default to the {@link MenuVisibilityHookOptions.toggleId} unless the
+   * {@link MenuVisibilityHookOptions.menuLabel} is provided.
+   *
+   * Note: Either the `aria-label` or `aria-labelledby` is required for
+   * accessibility.
+   */
+  "aria-labelledby": string | undefined;
+
+  /**
+   * An optional label describing the purpose of the menu that will be set to
+   * the {@link MenuVisibilityHookOptions.menuLabel}
+   */
+  "aria-label": string | undefined;
+
+  /**
+   * The orientation for the menu. This will be `"horizontal"` if
+   * {@link MenuVisibilityHookOptions.horizontal} is set to `true`, otherwise
+   * this will be `"vertical"`.
+   *
+   * @defaultValue `"vertical"`
+   */
+  "aria-orientation": "horizontal" | "vertical";
+
+  /**
+   * @see {@link MenuVisibilityHookOptions.toggleId}
+   * @defaultValue `${toggleId}-menu`
+   */
+  id: string;
+
+  /**
+   * A mouse event handler that handles closing the menu when any child elements
+   * are clicked.
+   */
+  onClick: MouseEventHandler<E>;
+
+  /**
+   * A keydown event handler that handles closing the menu if the escape key is
+   * pressed.
+   */
+  onKeyDown: KeyboardEventHandler<E>;
+}
+
+/**
+ *
+ * @see {@link https://www.w3.org/TR/wai-aria-practices/#menubutton}
+ * @typeParam E - The `HTMLElement` type for the toggle component. Defaults to
+ * `HTMLButtonElement`.
+ * @remarks \@since 4.0.0
+ */
+export interface MenuToggleRequiredProps<
+  E extends HTMLElement = HTMLButtonElement
+> {
+  /**
+   * This is set to `"menu"` to complete the menu button widget spec.
+   */
+  "aria-haspopup": "menu";
+
+  /**
+   * This will be set to `true` when the {@link MenuVisibilityState.visible} is
+   * `true`, otherwise this will be `undefined`.
+   */
+  "aria-expanded": boolean | undefined;
+
+  /**
+   * An id required for accessibility. This will be set to the
+   * {@link MenuVisibilityHookOptions.toggleId}
+   */
+  id: string;
+
+  /**
+   * A click handler that will toggle the visibility of the menu.
+   */
+  onClick: MouseEventHandler<E>;
+
+  /**
+   * A keydown handler that will show the menu if the `"ArrowUp"` or
+   * `"ArrowDown"` keys are pressed while focusing this element.
+   */
+  onKeyDown: KeyboardEventHandler<E>;
+}

--- a/packages/menu2/src/useMenu.ts
+++ b/packages/menu2/src/useMenu.ts
@@ -1,0 +1,172 @@
+import { KeyboardEvent, useEffect, useRef, useReducer, RefObject } from "react";
+
+export type MenuDefaultFocus = "self" | "first" | "last";
+/** @internal */
+const isValidMenuFocus = (value: unknown): value is MenuDefaultFocus =>
+  typeof value === "string" && ["first", "last", "self"].includes(value);
+
+interface MenuHookOptions {
+  baseId: string;
+  disableDeselect?: boolean;
+
+  [key: string]: unknown;
+}
+
+interface MenuVisibilityState {
+  /**
+   * Boolean if the menu is currently visible
+   *
+   * @defaultValue `false`
+   */
+  visible: boolean;
+
+  /** {@inheritdoc MenuDefaultFocus} */
+  defaultFocus: MenuDefaultFocus;
+}
+
+type MenuVisibilityAction =
+  | { type: "hide" }
+  | { type: "toggle" }
+  | { type: "show"; defaultFocus: MenuDefaultFocus };
+
+interface MenuHookReturnValue<
+  ToggleElement extends HTMLElement,
+  MenuElement extends HTMLElement
+> extends MenuVisibilityState {
+  menuRef: RefObject<MenuElement>;
+  toggleRef: RefObject<ToggleElement>;
+  showMenu(defaultFocus?: MenuDefaultFocus | unknown): void;
+  hideMenu(): void;
+  toggleMenu(): void;
+  onToggleKeyDown: <E extends Element>(event: KeyboardEvent<E>) => void;
+  onContextMenu: <E extends Element>(event: React.MouseEvent<E>) => void;
+}
+
+export function useMenu<
+  ToggleElement extends HTMLElement,
+  MenuElement extends HTMLElement
+>(options: MenuHookOptions): MenuHookReturnValue<ToggleElement, MenuElement> {
+  const { disableDeselect = false } = options;
+  const [state, dispatch] = useReducer(
+    function reducer(
+      state: MenuVisibilityState,
+      action: MenuVisibilityAction
+    ): MenuVisibilityState {
+      const { visible, defaultFocus } = state;
+      switch (action.type) {
+        case "show":
+          if (visible && defaultFocus === action.defaultFocus) {
+            return state;
+          }
+
+          return {
+            visible: true,
+            defaultFocus: action.defaultFocus,
+          };
+        case "hide":
+          if (!visible) {
+            return state;
+          }
+
+          return {
+            visible: false,
+            defaultFocus: state.defaultFocus,
+          };
+        case "toggle":
+          return {
+            visible: !visible,
+            defaultFocus: visible ? defaultFocus : "first",
+          };
+      }
+    },
+    undefined,
+    () =>
+      ({
+        visible: false,
+        defaultFocus: "first",
+      } as const)
+  );
+
+  const { visible, defaultFocus } = state;
+  const menuRef = useRef<MenuElement>(null);
+  const toggleRef = useRef<ToggleElement>(null);
+
+  const showMenu = (
+    defaultFocusOrUnknown: MenuDefaultFocus | undefined
+  ): void => {
+    const defaultFocus = isValidMenuFocus(defaultFocusOrUnknown)
+      ? defaultFocusOrUnknown
+      : "first";
+
+    dispatch({ type: "show", defaultFocus });
+  };
+  const hideMenu = (): void => {
+    dispatch({ type: "hide" });
+  };
+  const toggleMenu = (): void => {
+    dispatch({ type: "toggle" });
+  };
+
+  useEffect(() => {
+    if (!visible) {
+      return;
+    }
+
+    const handler = (event: MouseEvent): void => {
+      const { target } = event;
+      if (
+        !(target instanceof Element) ||
+        (menuRef.current?.contains(target) &&
+          toggleRef.current?.contains(target))
+      ) {
+        dispatch({ type: "hide" });
+      }
+    };
+
+    window.addEventListener("click", handler);
+    return () => {
+      window.removeEventListener("click", handler);
+    };
+  }, [visible]);
+
+  return {
+    visible,
+    defaultFocus,
+    menuRef,
+    toggleRef,
+    showMenu,
+    hideMenu,
+    toggleMenu,
+    onToggleKeyDown(event) {
+      if (event.isPropagationStopped()) {
+        return;
+      }
+
+      switch (event.key) {
+        case "ArrowUp":
+          event.stopPropagation();
+          event.preventDefault();
+          showMenu("last");
+          break;
+        case "ArrowDown":
+          event.stopPropagation();
+          event.preventDefault();
+          showMenu("first");
+          break;
+        case " ":
+          event.stopPropagation();
+          break;
+        case "Enter":
+          event.stopPropagation();
+      }
+    },
+    onContextMenu(event) {
+      event.preventDefault();
+      event.stopPropagation();
+      const selection = window.getSelection();
+      if (selection && !disableDeselect) {
+        selection.empty();
+      }
+    },
+  };
+}

--- a/packages/menu2/src/useMenuVisibility.ts
+++ b/packages/menu2/src/useMenuVisibility.ts
@@ -1,0 +1,307 @@
+import {
+  Dispatch,
+  RefObject,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+import type {
+  MenuDefaultFocus,
+  MenuToggleRequiredProps,
+  MenuVisibilityHookOptions,
+  MenuVisibilityState,
+  MenuWidgetRequiredProps,
+} from "./types";
+
+/** @internal */
+const isValidMenuFocus = (value: unknown): value is MenuDefaultFocus =>
+  typeof value === "string" && ["first", "last", "self"].includes(value);
+
+/**
+ * @typeParam ToggleElement - The `HTMLElement` type for the toggle component.
+ * Defaults to `HTMLButtonElement`.
+ * @typeParam MenuElement - The `HTMLElement` type for the menu component.
+ * Defaults to `HTMLDivElement`
+ * @remarks \@since 4.0.0
+ */
+export interface MenuVisibilityHookReturnValue<
+  ToggleElement extends HTMLElement = HTMLButtonElement,
+  MenuElement extends HTMLElement = HTMLDivElement
+> extends MenuVisibilityState {
+  /**
+   * A function that will show the menu with a {@link MenuDefaultFocus}. This
+   * allows for an `unknown` argument so that you can safely use this as an
+   * onClick handler without an additional arrow function.
+   *
+   * @example
+   * Click Handler
+   * ```ts
+   * // This is okay! It will default to `"first"`
+   * onClick={showMenu}
+   * ```
+   *
+   * @param defaultFocus - This should generally be one of the
+   * {@link MenuDefaultFocus} or `undefined` but can be any value.
+   */
+  showMenu(defaultFocus?: MenuDefaultFocus | unknown): void;
+
+  /**
+   * A function that will close the menu.
+   */
+  hideMenu(): void;
+
+  /**
+   * This _probably_ shouldn't be used externally, but this allows you to set
+   * the {@link MenuVisibilityState} if the {@link showMenu} and
+   * {@link hideMenu} functions do not work for your use case.
+   */
+  setMenuVisibilityState: Dispatch<SetStateAction<MenuVisibilityState>>;
+
+  /**
+   * A ref that **has** to be provided to the menu element since it is used to
+   * handle closing the menu if the user clicks outside of the menu. You can
+   * also use this ref yourself if you need to do anything with the menu DOM
+   * node.
+   */
+  menuRef: RefObject<MenuElement>;
+
+  /** {@inheritDoc MenuWidgetRequiredProps} */
+  menuProps: Readonly<MenuWidgetRequiredProps<MenuElement>>;
+
+  /**
+   * A ref that **has** to be provided to the toggle element since it is used to
+   * handle closing the menu if the user clicks outside of the menu and
+   * positioning the menu relative to this element. You can also use this ref
+   * yourself if you need to do anything with the menu DOM node.
+   */
+  toggleRef: RefObject<ToggleElement>;
+
+  /** {@inheritDoc MenuToggleRequiredProps} */
+  toggleProps: Readonly<MenuToggleRequiredProps<ToggleElement>>;
+}
+
+/**
+ * This hook is used to handle the visibility of menus and provide some the base
+ * accessibility requirements for the menu widget spec. This hook probably
+ * shouldn't be used externally since the {@link DropdownMenu} component should
+ * handle most use cases for you.
+ *
+ * @example
+ * Simple Example
+ * ```tsx
+ * import type { ReactElement } from "react";
+ * import { Button } from "@react-md/button"
+ * import { Menu, useMenuVisibility } from "@react-md/menu";
+ *
+ * function Example(): ReactElement {
+ *   const {
+ *     visible,
+ *     defaultFocus,
+ *     menuRef,
+ *     menuProps,
+ *     toggleRef,
+ *     toggleProps,
+ *     hideMenu,
+ *   } = useMenuVisibility({
+ *     toggleId: "some-unique-id",
+ *   });
+ *
+ *   return (
+ *     <>
+ *       <Button {...toggleProps} ref={toggleRef}>
+ *         Options...
+ *       </Button>
+ *       <Menu
+ *         {...menuProps}
+ *         menuRef={menuRef}
+ *         visible={visible}
+ *         defaultFocus={defaultFocus}
+ *         onRequestClose={hideMenu}
+ *       >
+ *         <MenuItem onClick={() => { /* do something *\/}}>Item 1</MenuItem>
+ *         <MenuItem onClick={() => { /* do something *\/}}>Item 2</MenuItem>
+ *         <MenuItem onClick={() => { /* do something *\/}}>Item 3</MenuItem>
+ *       </Menu>
+ *     </>
+ *   );
+ * }
+ * ```
+ *
+ * @see {@link https://www.w3.org/TR/wai-aria-practices/#menubutton}
+ * @typeParam ToggleElement - The `HTMLElement` type for the toggle component.
+ * Defaults to `HTMLButtonElement`.
+ * @typeParam MenuElement - The `HTMLElement` type for the menu component.
+ * Defaults to `HTMLDivElement`
+ * @param options - {@link MenuVisibilityHookOptions}
+ * @returns The {@link MenuVisibilityHookReturnValue}
+ * @remarks \@since 4.0.0
+ */
+export function useMenuVisibility<
+  ToggleElement extends HTMLElement = HTMLButtonElement,
+  MenuElement extends HTMLElement = HTMLDivElement
+>({
+  toggleId,
+  menuLabel,
+  horizontal = false,
+  onMenuClick,
+  onMenuKeyDown,
+  onToggleClick,
+  onToggleKeyDown,
+}: MenuVisibilityHookOptions<ToggleElement, MenuElement>): Readonly<
+  MenuVisibilityHookReturnValue<ToggleElement, MenuElement>
+> {
+  const menuId = `${toggleId}-menu`;
+  const menuRef = useRef<MenuElement>(null);
+  const toggleRef = useRef<ToggleElement>(null);
+  const [{ visible, defaultFocus }, setMenuVisibilityState] =
+    useState<MenuVisibilityState>({
+      visible: false,
+      defaultFocus: "first",
+    });
+  const showMenu = useCallback(
+    (defaultFocusOrUnknown?: MenuDefaultFocus | unknown) => {
+      const defaultFocus = isValidMenuFocus(defaultFocusOrUnknown)
+        ? defaultFocusOrUnknown
+        : "first";
+
+      setMenuVisibilityState({ visible: true, defaultFocus });
+    },
+    []
+  );
+  const hideMenu = useCallback(() => {
+    setMenuVisibilityState(({ defaultFocus }) => ({
+      visible: false,
+      defaultFocus,
+    }));
+  }, []);
+
+  useEffect(() => {
+    if (!visible) {
+      return;
+    }
+
+    const handler = ({ target }: MouseEvent): void => {
+      if (process.env.NODE_ENV !== "production") {
+        /* eslint-disable no-console */
+        const createMessage = (name: string): string =>
+          `The \`Menu\` component closed because the \`${name}\` is \`null\`. This normally happens because it was not passed to a valid DOM node.`;
+
+        if (!toggleRef.current) {
+          console.error(createMessage("toggleRef"));
+        }
+
+        if (!menuRef.current) {
+          console.error(createMessage("menuRef"));
+        }
+      }
+      if (
+        !(target instanceof Element) ||
+        (!menuRef.current?.contains(target) &&
+          !toggleRef.current?.contains(target))
+      ) {
+        setMenuVisibilityState(({ defaultFocus }) => ({
+          visible: false,
+          defaultFocus,
+        }));
+      }
+    };
+
+    window.addEventListener("click", handler);
+    return () => {
+      window.removeEventListener("click", handler);
+    };
+  }, [visible]);
+
+  return {
+    visible,
+    defaultFocus,
+    setMenuVisibilityState,
+    showMenu,
+    hideMenu,
+    menuRef,
+    menuProps: {
+      "aria-labelledby": menuLabel ? undefined : toggleId,
+      "aria-label": menuLabel || undefined,
+      "aria-orientation": horizontal ? "horizontal" : "vertical",
+      id: menuId,
+      onClick(event) {
+        onMenuClick?.(event);
+        if (event.isPropagationStopped()) {
+          return;
+        }
+
+        hideMenu();
+        toggleRef.current?.focus();
+      },
+      onKeyDown(event) {
+        onMenuKeyDown?.(event);
+        if (event.isPropagationStopped()) {
+          return;
+        }
+
+        switch (event.key) {
+          case "Escape":
+          case "Tab":
+            event.preventDefault();
+            event.stopPropagation();
+            hideMenu();
+            toggleRef.current?.focus();
+            break;
+        }
+      },
+    },
+    toggleRef,
+    toggleProps: {
+      "aria-haspopup": "menu",
+      "aria-expanded": visible || undefined,
+      id: toggleId,
+      onClick(event) {
+        onToggleClick?.(event);
+        if (event.isPropagationStopped()) {
+          return;
+        }
+
+        setMenuVisibilityState(({ defaultFocus, visible }) => {
+          if (visible) {
+            return {
+              defaultFocus,
+              visible: false,
+            };
+          }
+
+          return {
+            defaultFocus: "first",
+            visible: true,
+          };
+        });
+      },
+      onKeyDown(event) {
+        onToggleKeyDown?.(event);
+        if (event.isPropagationStopped()) {
+          return;
+        }
+
+        switch (event.key) {
+          case "ArrowUp":
+            event.stopPropagation();
+            event.preventDefault();
+            showMenu("last");
+            break;
+          case "ArrowDown":
+            event.stopPropagation();
+            event.preventDefault();
+            showMenu("first");
+            break;
+          case " ":
+            event.stopPropagation();
+            break;
+          case "Enter":
+            event.stopPropagation();
+        }
+      },
+    },
+  };
+}

--- a/packages/menu2/tsconfig.cjs.json
+++ b/packages/menu2/tsconfig.cjs.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": "src",
+    "outDir": "lib",
+    "baseUrl": ".",
+    "paths": { "@react-md/*": ["../*"] }
+  },
+  "include": ["src"],
+  "exclude": ["**/__tests__/*", "**/scssVariables.ts"],
+  "references": [
+    { "path": "../app-bar/tsconfig.cjs.json" },
+    { "path": "../button/tsconfig.cjs.json" },
+    { "path": "../divider/tsconfig.cjs.json" },
+    { "path": "../icon/tsconfig.cjs.json" },
+    { "path": "../list/tsconfig.cjs.json" },
+    { "path": "../states/tsconfig.cjs.json" },
+    { "path": "../transition/tsconfig.cjs.json" },
+    { "path": "../typography/tsconfig.cjs.json" },
+    { "path": "../utils/tsconfig.cjs.json" }
+  ]
+}

--- a/packages/menu2/tsconfig.ejs.json
+++ b/packages/menu2/tsconfig.ejs.json
@@ -1,0 +1,24 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "es",
+    "declaration": true,
+    "declarationDir": "types",
+    "baseUrl": ".",
+    "paths": { "@react-md/*": ["../*"] }
+  },
+  "include": ["src"],
+  "exclude": ["**/__tests__/*", "**/scssVariables.ts"],
+  "references": [
+    { "path": "../app-bar/tsconfig.ejs.json" },
+    { "path": "../button/tsconfig.ejs.json" },
+    { "path": "../divider/tsconfig.ejs.json" },
+    { "path": "../icon/tsconfig.ejs.json" },
+    { "path": "../list/tsconfig.ejs.json" },
+    { "path": "../states/tsconfig.ejs.json" },
+    { "path": "../transition/tsconfig.ejs.json" },
+    { "path": "../typography/tsconfig.ejs.json" },
+    { "path": "../utils/tsconfig.ejs.json" }
+  ]
+}

--- a/packages/menu2/tsconfig.json
+++ b/packages/menu2/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "noEmit": true, "composite": false },
+  "include": ["src"]
+}

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -59,6 +59,9 @@
       "path": "./packages/menu/tsconfig.cjs.json"
     },
     {
+      "path": "./packages/menu2/tsconfig.cjs.json"
+    },
+    {
       "path": "./packages/overlay/tsconfig.cjs.json"
     },
     {

--- a/tsconfig.ejs.json
+++ b/tsconfig.ejs.json
@@ -59,6 +59,9 @@
       "path": "./packages/menu/tsconfig.ejs.json"
     },
     {
+      "path": "./packages/menu2/tsconfig.ejs.json"
+    },
+    {
       "path": "./packages/overlay/tsconfig.ejs.json"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7740,6 +7740,11 @@ is-unicode-supported@^0.1.0:
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
 
+is-url-superb@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-url-superb/-/is-url-superb-4.0.0.tgz#b54d1d2499bb16792748ac967aa3ecb41a33a8c2"
+  integrity sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==
+
 is-utf8@^0.2.0, is-utf8@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
@@ -11434,7 +11439,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.6.1, prop-types@^15.7.2:
+"prop-types@>= 15.6", prop-types@^15.6.1, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7740,11 +7740,6 @@ is-unicode-supported@^0.1.0:
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
 
-is-url-superb@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/is-url-superb/-/is-url-superb-4.0.0.tgz#b54d1d2499bb16792748ac967aa3ecb41a33a8c2"
-  integrity sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==
-
 is-utf8@^0.2.0, is-utf8@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"


### PR DESCRIPTION
# Desired API

## Low-level with full control

```tsx
const { menuProps, toggleProps } = useMenu({
  id: 'my-menu',

  // default options
  // defaultVisible: false,
  // hoverable: false, // allow menus to be opened with the hover mode functionality instead of requiring a click
  // hoverTime: 0,
});

return (
  <>
    <Button {...toggleProps} buttonType="icon">
      <MoreVertSVGIcon />
    </Button>
    <Menu {...menuProps}>
      <MenuItem>Item 1</MenuItem>
      <MenuItem>Item 2</MenuItem>
      {/* etc */}
    </Menu>
  </>
);
```

## "Nice" Preset

```tsx
return (
  <DropdownMenu
    id="my-menu"
    buttonChildren={<MoreVertSVGIcon />}
    buttonType="icon"
    // same defaults as the useMenu hook for other options
    // hoverable
  >
    <MenuItem>Item 1</MenuItem>
    <MenuItem>Item 2</MenuItem>
    {/* etc */}
  </DropdownMenu>
);
```

## Nested Dropdown Menus

```tsx
return (
  <DropdownMenu
    id="my-menu"
    buttonChildren={<MoreVertSVGIcon />}
    buttonType="icon"
  >
    <MenuItem>Item 1</MenuItem>
    <MenuItem>Item 2</MenuItem>

    {/* This will actually be rendered as a `MenuItem` instead of a `Button`? */}
    {/* It would make refs a bit more difficult to type.. Might have to do `DropdownMenuItem` instead */}
    <DropdownMenu
      id="my-menu-nested"
      buttonChildren="Nested Dropdown Menu"
    >
      <MenuItem>Item 1</MenuItem>
      <MenuItem>Item 2</MenuItem>
    </DropdownMenu>
  </DropdownMenu>
);
```