### PR TITLE
Prevent event default when pressing enter with open AutoComplete

### DIFF
--- a/packages/autocomplete/src/useAutoComplete.ts
+++ b/packages/autocomplete/src/useAutoComplete.ts
@@ -393,6 +393,7 @@ export function useAutoComplete({
           break;
         case "Enter":
           if (visible && focusedIndex >= 0) {
+            event.preventDefault();
             event.stopPropagation();
             handleAutoComplete(focusedIndex);
             hide();


### PR DESCRIPTION
Fixes https://github.com/mlaursen/react-md/issues/194.

Note this commit is based on v2.9.1 because that is where I wanted to apply the fix. Please let me know the preferred approach to submitting fixes to multiple versions.

Codesandbox for reproducing the issue: https://codesandbox.io/s/react-md-autocomplete-submits-form-4hstxo?file=/src/App.tsx

I looked into adding a test, and the following passes, but it doesn't fail before the change, presumably because the fake DOM doesn't properly implement the submit event behavior (https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit_event).

```
  it("should not submit a form when the enter key selects an autocomplete item", async () => {
    const onSubmit = jest.fn();
    const { getByRole } = render(
      <form onSubmit={onSubmit}>
        <AutoComplete {...PROPS} />
      </form>
    );
    const input = getById<HTMLInputElement>("autocomplete");
    const getListbox = () => getByRole("listbox");

    fireEvent.keyDown(input, { key: "ArrowDown", altKey: true });
    fireEvent.keyDown(input, { key: "ArrowDown" });
    expect(input).toHaveAttribute(
      "aria-activedescendant",
      "autocomplete-listbox-result-1"
    );

    fireEvent.keyDown(input, { key: "Enter" });
    await waitForElementToBeRemoved(getListbox);
    expect(input.value).toBe("Alabama");

    expect(onSubmit).not.toHaveBeenCalled();
  });
```