### PR TITLE
fix: correct StatesConnfig to StatesConfig in v5-to-v6 migration guide

### DIFF
--- a/apps/docs/src/app/(main)/(markdown)/migration/v5-to-v6/page.mdx
+++ b/apps/docs/src/app/(main)/(markdown)/migration/v5-to-v6/page.mdx
@@ -3192,7 +3192,7 @@ The `CircularProgress` updated the following props:
 The `@react-md/states` packages was _mostly_ internal so codemods will not be provided
 to update this package.
 
-##### Replace `StatesConnfig` context provider
+##### Replace `StatesConfig` context provider
 
 The `StatesConfig` context provider has been removed in favor of the new
 `INTERACTION_CONFIG` object. Here is an example on how to update the `disableRipple`


### PR DESCRIPTION
## Summary
Fixes typo in the v5-to-v6 migration guide: `StatesConnfig` → `StatesConfig`.

Issue: #1493

## Changes
- Line 3195: Fixed heading `##### Replace \`StatesConnfig\` context provider` → `##### Replace \`StatesConfig\` context provider`

## Test Plan
- [x] Build passes (docs-only change)
- [x] Preview shows correct heading